### PR TITLE
Remove allow-unsafe config

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,12 +213,6 @@ diesel-guard check migrations/
 diesel-guard check migrations/ --format json
 ```
 
-### Allow unsafe operations
-
-```sh
-diesel-guard check migrations/ --allow-unsafe
-```
-
 ## Configuration
 
 Create a `diesel-guard.toml` file in your project root to customize behavior.

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,10 +26,6 @@ enum Commands {
         /// Output format (text or json)
         #[arg(long, default_value = "text")]
         format: String,
-
-        /// Allow unsafe operations (exit with 0 even if violations found)
-        #[arg(long)]
-        allow_unsafe: bool,
     },
 
     /// Initialize diesel-guard configuration file
@@ -54,11 +50,7 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Check {
-            path,
-            format,
-            allow_unsafe,
-        } => {
+        Commands::Check { path, format } => {
             // Load configuration with explicit error handling
             let config = match Config::load() {
                 Ok(config) => config,
@@ -93,7 +85,7 @@ fn main() -> Result<()> {
                 }
             }
 
-            if !allow_unsafe && total_violations > 0 {
+            if total_violations > 0 {
                 exit(1);
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed documentation for the `--allow-unsafe` CLI flag

The `--allow-unsafe` command-line argument is no longer available. The tool now exits with failure status whenever violations are detected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->