### PR TITLE
Add DropIndex check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ src/
 └── violation.rs     # Violation struct with operation/problem/solution
 
 tests/
-├── fixtures/        # Test migration files (13 fixtures: 7 safe, 12 unsafe)
+├── fixtures/        # Test migration files
 └── fixtures_test.rs # Integration tests
 ```
 
@@ -515,17 +515,6 @@ Users can wrap SQL in `-- safety-assured:start` / `-- safety-assured:end` blocks
   - ✅ `cargo test`
   - ✅ `cargo fmt --check`
   - ✅ `cargo clippy --all-targets --all-features -- -D warnings`
-
-- **Planned checks**: 18 checks in Coming Soon (Phase 2)
-  - See README.md for complete list
-
-## Dependencies
-
-- **sqlparser**: v0.60.0 - SQL parsing
-- **colored**: v3.0.0 - Terminal output formatting
-- **thiserror**: v2.0.17 - Error handling
-- **toml**: v0.9.8 - Metadata file parsing
-- **regex**: v1.10.0 - Custom pattern detection for unsupported SQL syntax
 
 ## Build & Development Commands
 

--- a/src/checks/drop_column.rs
+++ b/src/checks/drop_column.rs
@@ -11,7 +11,7 @@
 //! The recommended approach is to stage the removal: mark the column as unused
 //! in application code, deploy without references, and drop in a later migration.
 
-use crate::checks::Check;
+use crate::checks::{if_exists_clause, Check};
 use crate::violation::Violation;
 use sqlparser::ast::{AlterTable, AlterTableOperation, Statement};
 
@@ -62,7 +62,7 @@ impl Check for DropColumnCheck {
 Note: PostgreSQL doesn't support DROP COLUMN CONCURRENTLY. The rewrite is unavoidable but staging the removal reduces risk."#,
                                 table = table_name,
                                 column = column_name_str,
-                                if_exists = if *if_exists { " IF EXISTS" } else { "" }
+                                if_exists = if_exists_clause(*if_exists)
                             ),
                         )
                     })

--- a/src/checks/drop_index.rs
+++ b/src/checks/drop_index.rs
@@ -1,0 +1,156 @@
+//! Detection for DROP INDEX without CONCURRENTLY.
+//!
+//! This check identifies `DROP INDEX` statements that don't use the CONCURRENTLY
+//! option, which blocks queries during the index removal.
+//!
+//! Dropping an index without CONCURRENTLY acquires an ACCESS EXCLUSIVE lock on the
+//! table, which blocks all queries (SELECT, INSERT, UPDATE, DELETE) until the drop
+//! operation completes. Duration depends on system load and concurrent transactions.
+//!
+//! Using CONCURRENTLY (PostgreSQL 9.2+) allows the index to be dropped while permitting
+//! concurrent queries, though it takes longer and cannot be run inside a transaction block.
+//!
+//! **Parser Handling**: sqlparser cannot parse `DROP INDEX CONCURRENTLY` syntax, but
+//! diesel-guard detects this safe pattern and treats it as valid (returns no violations).
+//! A warning is shown that the file contains this safe pattern. Like CREATE INDEX
+//! CONCURRENTLY, it requires `metadata.toml` with `run_in_transaction = false`.
+
+use crate::checks::{if_exists_clause, Check};
+use crate::violation::Violation;
+use sqlparser::ast::{ObjectType, Statement};
+
+pub struct DropIndexCheck;
+
+impl Check for DropIndexCheck {
+    fn check(&self, stmt: &Statement) -> Vec<Violation> {
+        let mut violations = vec![];
+
+        if let Statement::Drop {
+            object_type,
+            if_exists,
+            names,
+            ..
+        } = stmt
+        {
+            // Check if this is dropping an index
+            if matches!(object_type, ObjectType::Index) {
+                // Flag all DROP INDEX statements since sqlparser cannot distinguish
+                // DROP INDEX CONCURRENTLY (which fails to parse)
+                for name in names {
+                    let index_name = name.to_string();
+                    let if_exists_str = if_exists_clause(*if_exists);
+
+                    violations.push(Violation::new(
+                        "DROP INDEX without CONCURRENTLY",
+                        format!(
+                            "Dropping index '{index}'{if_exists} without CONCURRENTLY acquires an ACCESS EXCLUSIVE lock, blocking all \
+                            queries (SELECT, INSERT, UPDATE, DELETE) on the table until complete. Duration depends on system load and concurrent transactions.",
+                            index = index_name,
+                            if_exists = if_exists_str
+                        ),
+                        format!(r#"Use CONCURRENTLY to drop the index without blocking queries:
+   DROP INDEX CONCURRENTLY{if_exists} {index};
+
+Note: CONCURRENTLY requires PostgreSQL 9.2+ and cannot be run inside a transaction block.
+
+Migration setup:
+1. Create metadata.toml in your migration directory:
+   run_in_transaction = false
+
+2. Use DROP INDEX CONCURRENTLY in your up.sql:
+   DROP INDEX CONCURRENTLY{if_exists} {index};
+
+Considerations:
+- Takes longer to complete than regular DROP INDEX
+- Allows concurrent SELECT, INSERT, UPDATE, DELETE operations
+- If it fails, the index may be marked "invalid" and should be dropped again
+- Cannot be rolled back (no transaction support)"#,
+                            if_exists = if_exists_str,
+                            index = index_name
+                        ),
+                    ));
+                }
+            }
+        }
+
+        violations
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_allows, assert_detects_violation};
+
+    #[test]
+    fn test_detects_drop_index() {
+        assert_detects_violation!(
+            DropIndexCheck,
+            "DROP INDEX idx_users_email;",
+            "DROP INDEX without CONCURRENTLY"
+        );
+    }
+
+    #[test]
+    fn test_detects_drop_index_if_exists() {
+        assert_detects_violation!(
+            DropIndexCheck,
+            "DROP INDEX IF EXISTS idx_users_email;",
+            "DROP INDEX without CONCURRENTLY"
+        );
+    }
+
+    #[test]
+    fn test_detects_drop_index_cascade() {
+        assert_detects_violation!(
+            DropIndexCheck,
+            "DROP INDEX idx_users_email CASCADE;",
+            "DROP INDEX without CONCURRENTLY"
+        );
+    }
+
+    #[test]
+    fn test_detects_drop_index_restrict() {
+        assert_detects_violation!(
+            DropIndexCheck,
+            "DROP INDEX idx_users_email RESTRICT;",
+            "DROP INDEX without CONCURRENTLY"
+        );
+    }
+
+    #[test]
+    fn test_detects_drop_multiple_indexes() {
+        use crate::checks::test_utils::parse_sql;
+
+        let check = DropIndexCheck;
+        let stmt = parse_sql("DROP INDEX idx1, idx2, idx3;");
+
+        let violations = check.check(&stmt);
+        assert_eq!(violations.len(), 3, "Should detect all 3 indexes");
+        assert!(violations
+            .iter()
+            .all(|v| v.operation == "DROP INDEX without CONCURRENTLY"));
+    }
+
+    #[test]
+    fn test_detects_drop_index_if_exists_cascade() {
+        assert_detects_violation!(
+            DropIndexCheck,
+            "DROP INDEX IF EXISTS idx_users_email CASCADE;",
+            "DROP INDEX without CONCURRENTLY"
+        );
+    }
+
+    #[test]
+    fn test_ignores_other_drop_statements() {
+        assert_allows!(DropIndexCheck, "DROP TABLE users;");
+    }
+
+    #[test]
+    fn test_ignores_other_statements() {
+        assert_allows!(
+            DropIndexCheck,
+            "CREATE INDEX idx_users_email ON users(email);"
+        );
+    }
+}

--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -6,6 +6,7 @@ mod add_unique_constraint;
 mod alter_column_type;
 mod create_extension;
 mod drop_column;
+mod drop_index;
 mod rename_column;
 mod rename_table;
 mod short_int_primary_key;
@@ -22,6 +23,7 @@ pub use add_unique_constraint::AddUniqueConstraintCheck;
 pub use alter_column_type::AlterColumnTypeCheck;
 pub use create_extension::CreateExtensionCheck;
 pub use drop_column::DropColumnCheck;
+pub use drop_index::DropIndexCheck;
 pub use rename_column::RenameColumnCheck;
 pub use rename_table::RenameTableCheck;
 pub use short_int_primary_key::ShortIntegerPrimaryKeyCheck;
@@ -44,6 +46,15 @@ mod helpers {
     pub fn unique_prefix(is_unique: bool) -> &'static str {
         if is_unique {
             "UNIQUE "
+        } else {
+            ""
+        }
+    }
+
+    /// Get SQL clause for IF EXISTS modifier
+    pub fn if_exists_clause(if_exists: bool) -> &'static str {
+        if if_exists {
+            " IF EXISTS"
         } else {
             ""
         }
@@ -93,6 +104,7 @@ impl Registry {
         self.register_check(config, AlterColumnTypeCheck);
         self.register_check(config, CreateExtensionCheck);
         self.register_check(config, DropColumnCheck);
+        self.register_check(config, DropIndexCheck);
         self.register_check(config, RenameColumnCheck);
         self.register_check(config, RenameTableCheck);
         self.register_check(config, ShortIntegerPrimaryKeyCheck);

--- a/src/parser/drop_index_concurrently_detector.rs
+++ b/src/parser/drop_index_concurrently_detector.rs
@@ -1,0 +1,56 @@
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex pattern to detect DROP INDEX CONCURRENTLY
+static DROP_INDEX_CONCURRENTLY_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)DROP\s+INDEX\s+CONCURRENTLY\s+").unwrap());
+
+/// Check if SQL contains DROP INDEX CONCURRENTLY syntax that sqlparser can't parse
+pub fn contains_drop_index_concurrently(sql: &str) -> bool {
+    DROP_INDEX_CONCURRENTLY_PATTERN.is_match(sql)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detects_drop_index_concurrently() {
+        assert!(contains_drop_index_concurrently(
+            "DROP INDEX CONCURRENTLY idx_users_email;"
+        ));
+    }
+
+    #[test]
+    fn test_detects_with_if_exists() {
+        assert!(contains_drop_index_concurrently(
+            "DROP INDEX CONCURRENTLY IF EXISTS idx_users_email;"
+        ));
+    }
+
+    #[test]
+    fn test_detects_case_insensitive() {
+        assert!(contains_drop_index_concurrently(
+            "drop index concurrently idx_users_email;"
+        ));
+    }
+
+    #[test]
+    fn test_ignores_regular_drop_index() {
+        assert!(!contains_drop_index_concurrently(
+            "DROP INDEX idx_users_email;"
+        ));
+    }
+
+    #[test]
+    fn test_ignores_drop_index_if_exists() {
+        assert!(!contains_drop_index_concurrently(
+            "DROP INDEX IF EXISTS idx_users_email;"
+        ));
+    }
+
+    #[test]
+    fn test_ignores_other_drop_statements() {
+        assert!(!contains_drop_index_concurrently("DROP TABLE users;"));
+    }
+}

--- a/tests/fixtures/drop_index_concurrently/metadata.toml
+++ b/tests/fixtures/drop_index_concurrently/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/tests/fixtures/drop_index_concurrently/up.sql
+++ b/tests/fixtures/drop_index_concurrently/up.sql
@@ -1,0 +1,2 @@
+-- Safe: Drop index with CONCURRENTLY
+DROP INDEX CONCURRENTLY idx_users_email;

--- a/tests/fixtures/drop_index_unsafe/up.sql
+++ b/tests/fixtures/drop_index_unsafe/up.sql
@@ -1,0 +1,2 @@
+-- Unsafe: Drop index without CONCURRENTLY
+DROP INDEX idx_users_email;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a check that flags unsafe DROP INDEX (without CONCURRENTLY) and suggests safer migration steps.

* **Documentation**
  * New guidance on dropping indexes non-concurrently with examples, metadata notes, navigation updates, and updated "Coming Soon" and safety sections; removed planned-checks subsection.

* **Parser Improvements**
  * Recognizes DROP INDEX CONCURRENTLY as a safe pattern to avoid parse failures.

* **Tests**
  * Added fixtures and tests for safe/unsafe drop-index scenarios; updated expectations.

* **Chores**
  * Added run_in_transaction metadata for the safe fixture; minor messaging tweaks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->