### PR TITLE
Fix CHECK constraint name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,16 +248,16 @@ For large tables, use a CHECK constraint approach that allows concurrent operati
 
 ```sql
 -- Step 1: Add CHECK constraint without validating existing rows
-ALTER TABLE users ADD CONSTRAINT email_not_null CHECK (email IS NOT NULL) NOT VALID;
+ALTER TABLE users ADD CONSTRAINT users_email_not_null_check CHECK (email IS NOT NULL) NOT VALID;
 
 -- Step 2: Validate separately (uses SHARE UPDATE EXCLUSIVE lock)
-ALTER TABLE users VALIDATE CONSTRAINT email_not_null;
+ALTER TABLE users VALIDATE CONSTRAINT users_email_not_null_check;
 
 -- Step 3: Add NOT NULL constraint (instant if CHECK exists)
 ALTER TABLE users ALTER COLUMN email SET NOT NULL;
 
 -- Step 4: Optionally drop redundant CHECK constraint
-ALTER TABLE users DROP CONSTRAINT email_not_null;
+ALTER TABLE users DROP CONSTRAINT users_email_not_null_check;
 ```
 
 The VALIDATE step allows concurrent reads and writes, only blocking other schema changes. On PostgreSQL 12+, NOT NULL constraints are more efficient, but this approach still provides better control.


### PR DESCRIPTION
To follow "Best practices for constraint naming":

> ### Best practices for constraint naming:
>
>  CHECK: `{table}_{column}_check` or `{table}_{description}_check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README examples to use consistent constraint names (renamed constraint identifiers across the step-by-step SQL examples for clarity).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->