### PR TITLE
Add spans and source code to parse errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use miette::{Diagnostic, SourceSpan};
+use miette::{Diagnostic, NamedSource, SourceOffset, SourceSpan};
 use thiserror::Error;
 
 #[derive(Error, Debug, Diagnostic)]
@@ -12,7 +12,7 @@ pub enum DieselGuardError {
     ParseError {
         msg: String,
         #[source_code]
-        src: Option<String>,
+        src: Option<NamedSource<String>>,
         #[label("problematic SQL")]
         span: Option<SourceSpan>,
     },
@@ -49,18 +49,61 @@ impl DieselGuardError {
         }
     }
 
-    /// Create a parse error with source code context
-    pub fn parse_error_with_source(
-        msg: impl Into<String>,
-        src: impl Into<String>,
-        span: Option<SourceSpan>,
-    ) -> Self {
-        Self::ParseError {
-            msg: msg.into(),
-            src: Some(src.into()),
-            span,
+    /// Attach file context to an existing error.
+    ///
+    /// For parse errors, this adds the source code with filename and computes
+    /// the span from any line/column info in the error message.
+    pub fn with_file_context(self, path: &str, source: String) -> Self {
+        match self {
+            Self::ParseError { msg, .. } => {
+                let span = parse_location(&msg)
+                    .map(|(line, col)| SourceOffset::from_location(&source, line, col).into());
+
+                Self::ParseError {
+                    msg,
+                    src: Some(NamedSource::new(path, source)),
+                    span,
+                }
+            }
+            other => other,
         }
     }
 }
 
+/// Parse line and column from sqlparser error messages.
+///
+/// Format: `"... at Line: {line}, Column: {column}"`
+fn parse_location(msg: &str) -> Option<(usize, usize)> {
+    let (_, after_line) = msg.split_once("at Line: ")?;
+    let (line_str, col_str) = after_line.split_once(", Column: ")?;
+
+    let line = line_str.parse().ok()?;
+    let col = col_str.parse().ok()?;
+
+    Some((line, col))
+}
+
 pub type Result<T> = std::result::Result<T, DieselGuardError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_location() {
+        let msg = "sql parser error: Expected: a list of columns in parentheses, found: INDEX at Line: 5, Column: 59";
+        assert_eq!(parse_location(msg), Some((5, 59)));
+    }
+
+    #[test]
+    fn test_parse_location_no_location() {
+        let msg = "some error without location info";
+        assert_eq!(parse_location(msg), None);
+    }
+
+    #[test]
+    fn test_parse_location_single_digit() {
+        let msg = "error at Line: 1, Column: 1";
+        assert_eq!(parse_location(msg), Some((1, 1)));
+    }
+}

--- a/src/safety_checker.rs
+++ b/src/safety_checker.rs
@@ -50,6 +50,7 @@ impl SafetyChecker {
     pub fn check_file(&self, path: &Utf8Path) -> Result<Vec<Violation>> {
         let sql = fs::read_to_string(path)?;
         self.check_sql(&sql)
+            .map_err(|e| e.with_file_context(path.as_str(), sql.clone()))
     }
 
     /// Check all migration files in a directory


### PR DESCRIPTION
Before this PR it was impossible to understand what file the parse error originated from since the error message did not include the path to the migration file. With this PR we now include the path of the migration file and the annotated source code, which makes it much easier to understand where the issue is coming from.

Unfortunately `sqlparser` does not provide the line/column information in a structured form, so we have to fall back to parsing the metadata from the error message.

### Before
<img width="1059" height="108" alt="Bildschirmfoto 2025-12-12 um 11 15 02" src="https://github.com/user-attachments/assets/19d867e2-6976-4aae-82d8-d6304e119920" />

### After
<img width="1085" height="270" alt="Bildschirmfoto 2025-12-12 um 11 33 59" src="https://github.com/user-attachments/assets/34d7dc52-15cd-44d3-b7e7-f9572a1a9573" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages by attaching file path and source content plus computed location info for clearer diagnostics.
  * Error propagation updated so checks include file context on failure.

* **New Features**
  * Public API updated to support attaching file context and auto-extracting location from error text.

* **Tests**
  * Added unit tests covering location parsing for various error message formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->