### PR TITLE
Do not ignore check_down when checking a specific migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          draft: false
+          draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -627,6 +627,7 @@ fn test_check_all_sqlx_fixtures() {
     use diesel_guard::Config;
 
     let config = Config {
+        framework: "sqlx".to_string(),
         check_down: false, // Only check up migrations
         ..Default::default()
     };
@@ -656,24 +657,20 @@ fn test_check_all_sqlx_fixtures() {
         }
     }
 
-    // Note: We're actually finding 5 files because the suffix fixture has both
-    // .up.sql and .down.sql, and both have violations (even with check_down=false,
-    // the down.sql file still gets processed since it's a separate file, not a section)
     // Expected violations (with check_down = false):
     // 1. sqlx_suffix_add_column_unsafe/.up.sql - 1 violation (ADD COLUMN with DEFAULT)
-    // 2. sqlx_suffix_add_column_unsafe/.down.sql - 1 violation (DROP COLUMN)
-    // 3. sqlx_marker_drop_column - 1 violation (DROP COLUMN in up section)
-    // 4. sqlx_directory_rename_column/up.sql - 1 violation (RENAME COLUMN)
-    // 5. sqlx_reindex_unsafe - 1 violation (REINDEX without CONCURRENTLY)
-    // Note: CONCURRENTLY and safe fixtures have 0 violations
+    // 2. sqlx_marker_drop_column - 1 violation (DROP COLUMN in up section)
+    // 3. sqlx_directory_rename_column/up.sql - 1 violation (RENAME COLUMN)
+    // 4. sqlx_reindex_unsafe - 1 violation (REINDEX without CONCURRENTLY)
+    // Note: .down.sql correctly skipped, CONCURRENTLY and safe fixtures have 0 violations
     assert_eq!(
-        files_with_violations, 5,
-        "Expected 5 files with violations, got {}",
+        files_with_violations, 4,
+        "Expected 4 files with violations, got {}",
         files_with_violations
     );
     assert_eq!(
-        all_violations, 5,
-        "Expected 5 total violations, got {}",
+        all_violations, 4,
+        "Expected 4 total violations, got {}",
         all_violations
     );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable framework option to enable SQLx-specific migration handling.

* **Bug Fixes**
  * Improved detection of single-migration directories so only appropriate migration files are processed.
  * Ensured .down.sql files are skipped or included correctly according to the check_down setting.

* **Tests**
  * Added tests covering single-migration directory and check_down behaviors.

* **Documentation**
  * Updated contributor and architecture guidance to clarify detector and adapter responsibilities.

* **Chores**
  * CI release workflow now creates draft releases by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->