### PR TITLE
Add stdin input for the check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Safe alternative:
   Note: For Postgres 11+, this is safe if the default is a constant value.
 ```
 
+You can also pipe the SQL migration directly, to get the same effect:
+
+```sh
+cat migrations/2024_01_01_create_users/up.sql | diesel-guard check -
+```
+
 ## Supported Frameworks
 
 diesel-guard supports both **Diesel** and **SQLx** Postgres migrations. The framework is configured via `diesel-guard.toml` (see [Configuration](#configuration)).

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ struct Cli {
 enum Commands {
     /// Check migrations for unsafe operations
     Check {
-        /// Path to migration file or directory
+        /// Path to migration file or directory or "-" for stdin input
         path: Utf8PathBuf,
 
         /// Output format (text or json)

--- a/src/safety_checker.rs
+++ b/src/safety_checker.rs
@@ -7,6 +7,7 @@ use crate::scripting;
 use crate::violation::Violation;
 use camino::Utf8Path;
 use std::fs;
+use std::io::{self, BufRead, BufReader};
 
 pub struct SafetyChecker {
     registry: Registry,
@@ -162,9 +163,24 @@ impl SafetyChecker {
         Ok(results)
     }
 
-    /// Check a path (file or directory)
+    // check a migration string from a buffer
+    fn check_buffer(&self, reader: &mut dyn BufRead) -> Result<Vec<Violation>> {
+        let mut buffer = String::new();
+        reader.read_to_string(&mut buffer)?;
+        self.check_sql(&buffer)
+    }
+
+    /// Check a path (file, directory or stdin)
     pub fn check_path(&self, path: &Utf8Path) -> Result<Vec<(String, Vec<Violation>)>> {
-        if path.is_dir() {
+        // "-" means we're using stdin as an input.
+        if path.as_str() == "-" {
+            let violations = self.check_buffer(&mut BufReader::new(io::stdin().lock()))?;
+            if violations.is_empty() {
+                Ok(vec![])
+            } else {
+                Ok(vec![(path.to_string(), violations)])
+            }
+        } else if path.is_dir() {
             self.check_directory(path)
         } else {
             let violations = self.check_file(path)?;
@@ -185,6 +201,8 @@ impl Default for SafetyChecker {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
     use super::*;
 
     #[test]
@@ -278,5 +296,48 @@ mod tests {
             result.unwrap_err().to_string(),
             "Invalid framework \"unknown\". Expected \"diesel\" or \"sqlx\"."
         );
+    }
+
+    #[test]
+    fn test_buffer_input_safe_sql() {
+        let checker: SafetyChecker = SafetyChecker::new();
+        let input_data = "ALTER TABLE users ADD COLUMN foo TEXT;";
+        let violations = checker
+            .check_buffer(&mut BufReader::new(Cursor::new(input_data)))
+            .unwrap();
+        assert_eq!(violations.len(), 0)
+    }
+
+    #[test]
+    fn test_buffer_input_unsafe_sql() {
+        let checker: SafetyChecker = SafetyChecker::new();
+        let input_data = "ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;";
+        let violations = checker
+            .check_buffer(&mut BufReader::new(Cursor::new(input_data)))
+            .unwrap();
+        assert_eq!(violations.len(), 1)
+    }
+
+    #[test]
+    fn test_buffer_empty_string() {
+        let checker: SafetyChecker = SafetyChecker::new();
+        let input_data = "";
+        let violations = checker
+            .check_buffer(&mut BufReader::new(Cursor::new(input_data)))
+            .unwrap();
+        assert_eq!(violations.len(), 0)
+    }
+
+    #[test]
+    fn test_buffer_input_multiple_lines() {
+        let checker: SafetyChecker = SafetyChecker::new();
+        let input_data = r#"
+            REINDEX INDEX idx_users_email;
+            REINDEX TABLE posts;
+        "#;
+        let violations = checker
+            .check_buffer(&mut BufReader::new(Cursor::new(input_data)))
+            .unwrap();
+        assert_eq!(violations.len(), 2)
     }
 }

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -1,0 +1,57 @@
+use std::{
+    io::Write,
+    path::PathBuf,
+    process::{Command, Stdio},
+};
+
+/// Get the path to the diesel-guard binary
+fn diesel_guard_bin() -> PathBuf {
+    // Build the binary first to ensure it exists
+    let status = Command::new("cargo")
+        .args(["build", "--quiet"])
+        .status()
+        .expect("Failed to build diesel-guard");
+    assert!(status.success(), "Failed to build diesel-guard");
+
+    // Get the binary path
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("target");
+    path.push("debug");
+    path.push("diesel-guard");
+    path
+}
+
+#[test]
+fn test_stdin_input_safe() {
+    // Create pipes for the command
+    let command_input = Stdio::piped();
+    let command_output = Stdio::piped();
+
+    // Create test data for the command
+    let test_data = "ALTER TABLE users ADD COLUMN foo TEXT;";
+
+    // Run check command
+    let mut handle = Command::new(diesel_guard_bin())
+        .arg("check")
+        .arg("-")
+        .stdin(command_input)
+        .stdout(command_output)
+        .spawn()
+        .expect("Failed to execute check command");
+
+    let handle_stdin = handle.stdin.as_mut().unwrap();
+    handle_stdin.write_all(test_data.as_bytes()).unwrap();
+
+    let output = handle.wait_with_output().unwrap();
+
+    // Verify command succeeded
+    assert!(
+        output.status.success(),
+        "Check command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify output message
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("✅ No unsafe migrations detected!\n"));
+}


### PR DESCRIPTION
Hello!

This PR implements a feature that allows `diesel-guard check` to read input from stdin.
This enables support for linux pipes and editor integrations.

```bash
echo "ALTER TABLE users ADD COLUMN foo TEXT;" | diesel-guard check -
echo "ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;" | diesel-guard check -
cat migration.sql | diesel-guard check -
```

Closes #90 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support piping SQL into the tool via stdin (accepts "-" as input source) with buffered input handling.

* **Documentation**
  * Added examples showing how to pipe SQL migrations using shell pipelines.

* **Tests**
  * Added unit and integration tests covering stdin/buffered input, multi-line and empty input cases.

* **Bug Fixes**
  * Improved handling of empty stdin input to avoid false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->