### PR TITLE
docs: Add mdbook-sitemap-generator

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,16 @@ jobs:
           mkdir mdbook
           curl -sSL $url | tar -xz --directory=./mdbook
           echo "$(pwd)/mdbook" >> $GITHUB_PATH
+      - name: Cache cargo tools
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-mdbook-tools
+      - name: Install mdbook-sitemap-generator
+        run: cargo install mdbook-sitemap-generator
       - run: mdbook build docs
+      - name: Generate sitemap
+        run: mdbook-sitemap-generator -d https://ayarotsky.github.io/diesel-guard -r ./docs/book
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs/book

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Diesel Guard
 
-![Build Status](https://github.com/ayarotsky/diesel-guard/actions/workflows/ci.yml/badge.svg?branch=main) [![codecov](https://codecov.io/github/ayarotsky/diesel-guard/graph/badge.svg?token=YCBD10IGNU)](https://codecov.io/github/ayarotsky/diesel-guard) [![crates.io](https://img.shields.io/crates/v/diesel-guard)](https://crates.io/crates/diesel-guard) [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+![Build Status](https://github.com/ayarotsky/diesel-guard/actions/workflows/ci.yml/badge.svg?branch=main) [![crates.io](https://img.shields.io/crates/v/diesel-guard)](https://crates.io/crates/diesel-guard) [![docs](https://img.shields.io/badge/docs-documentation-blue)](https://ayarotsky.github.io/diesel-guard/) [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![codecov](https://codecov.io/github/ayarotsky/diesel-guard/graph/badge.svg?token=YCBD10IGNU)](https://codecov.io/github/ayarotsky/diesel-guard)
 
 **Catch dangerous Postgres migrations before they take down production.**
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -5,6 +5,7 @@ language = "en"
 src = "src"
 
 [output.html]
+site-url = "/diesel-guard/"
 git-repository-url = "https://github.com/ayarotsky/diesel-guard"
 edit-url-template = "https://github.com/ayarotsky/diesel-guard/edit/main/docs/src/{path}"
 default-theme = "light"

--- a/docs/src/robots.txt
+++ b/docs/src/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://ayarotsky.github.io/diesel-guard/sitemap.xml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Redesigned README with demo image, updated badges, expanded feature list, and noted Diesel/SQLx compatibility
  * Added site configuration and robots.txt to improve documentation indexing and discovery
* **Chores**
  * Enabled automated sitemap generation and build caching in the docs build to speed publishes and ensure up-to-date site maps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->