### PR TITLE
Parse Diesel and SQLx migration metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,8 @@ flowchart TD
     LOOP -->|not ignored| EN["extract_node()<br/>RawStmt → NodeEnum"]
 
     EN --> FAN["for each Check in Registry"]
-    FAN --> BI["BuiltInCheck::check(node, config)"]
-    FAN --> RH["CustomCheck::check(node, config)<br/>(Rhai engine eval)"]
+    FAN --> BI["BuiltInCheck::check(node, config, ctx)"]
+    FAN --> RH["CustomCheck::check(node, config, ctx)<br/>(Rhai engine eval)"]
 
     BI --> COLL["collect Vec&lt;Violation&gt;"]
     RH --> COLL
@@ -47,7 +47,7 @@ flowchart LR
     COMPILE -->|ok| CC["CustomCheck<br/>(Engine + AST)"]
     CC --> REG["Registry.add_check()"]
     REG --> EXEC["Check::check()<br/>called per NodeEnum"]
-    EXEC --> RHAI["Rhai script<br/>receives node + config"]
+    EXEC --> RHAI["Rhai script<br/>receives node, config, ctx"]
     RHAI -->|"()"| NONE["no violation"]
     RHAI -->|"#{ operation, ... }"| ONE["one Violation"]
     RHAI -->|"[#{ ... }, ...]"| MANY["multiple Violations"]
@@ -66,7 +66,7 @@ The pattern is always the same: bail early if the node is not the type you care 
 pub struct AddIndexCheck;
 
 impl Check for AddIndexCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let NodeEnum::IndexStmt(stmt) = node else {
             return vec![];  // not a CREATE INDEX — ignore
         };
@@ -84,7 +84,7 @@ impl Check for AddIndexCheck {
 
 ```rust
 impl Check for AddColumnCheck {
-    fn check(&self, node: &NodeEnum, config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let Some((table_name, cmds)) = alter_table_cmds(node) else {
             return vec![];
         };
@@ -109,7 +109,7 @@ impl Check for AddColumnCheck {
 }
 ```
 
-Use `_config` when the check has no version-specific logic; use `config` when it does. Compare `config.postgres_version >= Some(N)` — `None` means unknown, so the safe path is to flag the violation.
+Use `_config` when the check has no version-specific logic; use `config` when it does. Use `_ctx` when the check does not inspect transaction context; use `ctx` when it does (currently only `AddIndexCheck`, `DropIndexCheck`, `ReindexCheck`). Compare `config.postgres_version >= Some(N)` — `None` means unknown, so the safe path is to flag the violation.
 
 **Watch out:** `ALTER TABLE ... RENAME COLUMN/TO` is parsed as `RenameStmt`, not `AlterTableStmt`. It will never appear in `alter_table_cmds()` — match on `NodeEnum::RenameStmt` directly and use `rename_type` to distinguish column from table renames.
 
@@ -123,7 +123,7 @@ Use `diesel-guard dump-ast --sql "..."` to inspect what AST a statement produces
 
 ## Adding a New Check
 
-1. **Create** `src/checks/your_check.rs` — implement the `Check` trait. Use `_config` if unused, `config` if version-aware. Add `#[cfg(test)]` unit tests using the macros above.
+1. **Create** `src/checks/your_check.rs` — implement the `Check` trait. Use `_config` if unused, `config` if version-aware. Use `_ctx` if unused, `ctx` if the check needs to know whether the migration runs inside a transaction (e.g. for CONCURRENTLY operations). Add `#[cfg(test)]` unit tests using the macros above.
 2. **Register** in `src/checks/mod.rs` — add `mod`, `pub use`, and `self.register_check(config, YourCheck)` call inside `Registry::with_config()` (all alphabetically). Check names are derived from struct names automatically. (`register_check` is the private built-in registration path; `add_check` is the public API used only for custom Rhai checks.)
 3. **Create fixtures** — `tests/fixtures/your_operation_{safe,unsafe}/up.sql`. First line MUST be `-- Safe: ...` or `-- Unsafe: ...`.
 4. **Update integration tests** in `tests/fixtures_test.rs` — add to `safe_fixtures` vec, add detection test, update `test_check_entire_fixtures_directory` counts.
@@ -140,8 +140,8 @@ Use `diesel-guard dump-ast --sql "..."` to inspect what AST a statement produces
 
 Users place `.rhai` files in a directory and set `custom_checks_dir` in `diesel-guard.toml`.
 
-- Each script receives a `node` variable (pg_query AST node serialized via `rhai::serde::to_dynamic()`) and a `config` variable (current config settings)
-- Scripts access fields like `node.IndexStmt.concurrent`, `node.CreateStmt.relation.relname`; access config like `config.postgres_version` (integer or `()` when unset)
+- Each script receives a `node` variable (pg_query AST node serialized via `rhai::serde::to_dynamic()`), a `config` variable (current config settings), and a `ctx` variable (per-migration metadata: `ctx.run_in_transaction`, `ctx.no_transaction_hint`).
+- Scripts access fields like `node.IndexStmt.concurrent`, `node.CreateStmt.relation.relname`; access config like `config.postgres_version` (integer or `()` when unset); access migration context like `ctx.run_in_transaction` (bool) and `ctx.no_transaction_hint` (string)
 - Return protocol: `()` = no violation, `#{ operation, problem, safe_alternative }` = one violation, array of maps = multiple
 - Check name = filename stem (e.g., `require_concurrent.rhai` → `require_concurrent`); disableable via `disable_checks`
 - Safety-assured blocks automatically skip custom checks (same `check_stmts_with_context` path)
@@ -192,6 +192,14 @@ assert_detects_violation_containing!(Check, sql, "OP", "substr")  // violation p
 assert_detects_n_violations!(Check, sql, n, "OPERATION NAME")     // exactly N violations
 assert_allows!(Check, sql)                                         // no violations
 assert_allows_with_config!(Check, sql, config)                     // no violations with explicit config
+```
+
+All macros pass `MigrationContext::default()` (`run_in_transaction: true`). For checks that are context-aware (currently `AddIndexCheck`, `DropIndexCheck`, `ReindexCheck`), call `check()` directly with an explicit `MigrationContext` when testing the no-transaction path:
+
+```rust
+let ctx = MigrationContext { run_in_transaction: false, no_transaction_hint: "" };
+let violations = AddIndexCheck.check(&node, &Config::default(), &ctx);
+assert!(violations.is_empty());
 ```
 
 **Integration tests** in `tests/fixtures_test.rs` run `SafetyChecker` against real `.sql` files under `tests/fixtures/`. Each fixture is a directory containing an `up.sql` whose first line declares its intent:

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,9 +3,11 @@ coverage:
     project:
       default:
         informational: false
+        threshold: 0%
     patch:
       default:
         informational: false
+        threshold: 0%
 
 comment:
   layout: "reach,diff,flags,files"

--- a/docs/src/checks/overview.md
+++ b/docs/src/checks/overview.md
@@ -5,7 +5,7 @@ diesel-guard ships with 24 built-in safety checks covering the most common Postg
 | Check | Operation | Lock Type |
 |---|---|---|
 | [ADD COLUMN with DEFAULT](add-column-default.md) | `ALTER TABLE ... ADD COLUMN ... DEFAULT` | ACCESS EXCLUSIVE + table rewrite |
-| [Adding an Index](adding-index.md) | `CREATE INDEX` without `CONCURRENTLY` | SHARE |
+| [Adding an Index](adding-index.md) | `CREATE INDEX` without `CONCURRENTLY`; `CREATE INDEX CONCURRENTLY` inside a transaction | SHARE |
 | [Adding a UNIQUE Constraint](adding-unique-constraint.md) | `ALTER TABLE ... ADD UNIQUE` | ACCESS EXCLUSIVE |
 | [Changing Column Type](changing-column-type.md) | `ALTER TABLE ... ALTER COLUMN ... TYPE` | ACCESS EXCLUSIVE + table rewrite |
 | [CHAR Fields](char-field.md) | `CHAR`/`CHARACTER` column types | — (best practice) |
@@ -13,7 +13,7 @@ diesel-guard ships with 24 built-in safety checks covering the most common Postg
 | [Dropping a Column](dropping-column.md) | `ALTER TABLE ... DROP COLUMN` | ACCESS EXCLUSIVE |
 | [Dropping a Constraint](dropping-constraint.md) | Unnamed `UNIQUE`/`FOREIGN KEY`/`CHECK` constraints | — (best practice) |
 | [Dropping a Database](dropping-database.md) | `DROP DATABASE` | Exclusive access |
-| [Dropping an Index](dropping-index.md) | `DROP INDEX` without `CONCURRENTLY` | ACCESS EXCLUSIVE |
+| [Dropping an Index](dropping-index.md) | `DROP INDEX` without `CONCURRENTLY`; `DROP INDEX CONCURRENTLY` inside a transaction | ACCESS EXCLUSIVE |
 | [Dropping a Primary Key](dropping-primary-key.md) | `ALTER TABLE ... DROP CONSTRAINT ... pkey` | ACCESS EXCLUSIVE |
 | [Dropping a Table](dropping-table.md) | `DROP TABLE` | ACCESS EXCLUSIVE |
 | [Generated Columns](generated-column.md) | `ADD COLUMN ... GENERATED ALWAYS AS ... STORED` | ACCESS EXCLUSIVE + table rewrite |
@@ -21,7 +21,7 @@ diesel-guard ships with 24 built-in safety checks covering the most common Postg
 | [Wide Indexes](multiple-column-index.md) | `CREATE INDEX` with 4+ columns | — (best practice) |
 | [Renaming a Column](renaming-column.md) | `ALTER TABLE ... RENAME COLUMN` | ACCESS EXCLUSIVE |
 | [Renaming a Table](renaming-table.md) | `ALTER TABLE ... RENAME TO` | ACCESS EXCLUSIVE |
-| [REINDEX](reindexing.md) | `REINDEX` without `CONCURRENTLY` | ACCESS EXCLUSIVE |
+| [REINDEX](reindexing.md) | `REINDEX` without `CONCURRENTLY`; `REINDEX CONCURRENTLY` inside a transaction | ACCESS EXCLUSIVE |
 | [SERIAL Primary Keys](serial-primary-key.md) | `ADD COLUMN ... SERIAL/BIGSERIAL` | ACCESS EXCLUSIVE + table rewrite |
 | [SET NOT NULL](set-not-null.md) | `ALTER TABLE ... ALTER COLUMN ... SET NOT NULL` | ACCESS EXCLUSIVE |
 | [Short Primary Keys](short-primary-key.md) | `SMALLINT`/`INT` primary keys | — (best practice) |

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -55,7 +55,7 @@ Use these names in `disable_checks` (blacklist) or `enable_checks` (whitelist):
 | Check Name | Operation |
 |---|---|
 | `AddColumnCheck` | ADD COLUMN with DEFAULT |
-| `AddIndexCheck` | CREATE INDEX without CONCURRENTLY |
+| `AddIndexCheck` | CREATE INDEX without CONCURRENTLY; CONCURRENTLY inside a transaction |
 | `AddJsonColumnCheck` | ADD COLUMN with JSON type |
 | `AddNotNullCheck` | ALTER COLUMN SET NOT NULL |
 | `AddPrimaryKeyCheck` | ADD PRIMARY KEY to existing table |
@@ -66,11 +66,11 @@ Use these names in `disable_checks` (blacklist) or `enable_checks` (whitelist):
 | `CreateExtensionCheck` | CREATE EXTENSION |
 | `DropColumnCheck` | DROP COLUMN |
 | `DropDatabaseCheck` | DROP DATABASE |
-| `DropIndexCheck` | DROP INDEX without CONCURRENTLY |
+| `DropIndexCheck` | DROP INDEX without CONCURRENTLY; CONCURRENTLY inside a transaction |
 | `DropPrimaryKeyCheck` | DROP PRIMARY KEY |
 | `DropTableCheck` | DROP TABLE |
 | `GeneratedColumnCheck` | ADD COLUMN with GENERATED STORED |
-| `ReindexCheck` | REINDEX without CONCURRENTLY |
+| `ReindexCheck` | REINDEX without CONCURRENTLY; CONCURRENTLY inside a transaction |
 | `RenameColumnCheck` | RENAME COLUMN |
 | `RenameTableCheck` | RENAME TABLE |
 | `ShortIntegerPrimaryKeyCheck` | SMALLINT/INT/INTEGER primary keys |

--- a/docs/src/custom-checks.md
+++ b/docs/src/custom-checks.md
@@ -20,10 +20,21 @@ if stmt == () { return; }
 
 if !stmt.concurrent {
     let idx_name = if stmt.idxname != "" { stmt.idxname } else { "(unnamed)" };
-    #{
+    return #{
         operation: "INDEX without CONCURRENTLY: " + idx_name,
         problem: "Creating index '" + idx_name + "' without CONCURRENTLY blocks writes on the table.",
         safe_alternative: "Use CREATE INDEX CONCURRENTLY:\n  CREATE INDEX CONCURRENTLY " + idx_name + " ON ...;"
+    };
+}
+
+// CONCURRENTLY cannot run inside a transaction block
+if ctx.run_in_transaction {
+    let idx_name = if stmt.idxname != "" { stmt.idxname } else { "(unnamed)" };
+    let hint = if ctx.no_transaction_hint != "" { ctx.no_transaction_hint } else { "Run this migration outside a transaction block." };
+    #{
+        operation: "INDEX CONCURRENTLY inside a transaction: " + idx_name,
+        problem: "CREATE INDEX CONCURRENTLY cannot run inside a transaction block. PostgreSQL will raise an error at runtime.",
+        safe_alternative: hint
     }
 }
 ```
@@ -45,6 +56,7 @@ diesel-guard check migrations/
 - Each `.rhai` script is called **once per SQL statement** in the migration
 - The `node` variable contains the pg_query AST for that statement (a nested map)
 - The `config` variable exposes the current `diesel-guard.toml` settings (e.g., `config.postgres_version`)
+- The `ctx` variable exposes per-migration metadata (e.g., `ctx.run_in_transaction`)
 - Scripts match on a specific node type: `let stmt = node.IndexStmt;`
 - If the node doesn't match, `node.IndexStmt` returns `()` — early-return with `if stmt == () { return; }`
 - Return `()` for no violation, a map for one, or an array of maps for multiple
@@ -66,6 +78,39 @@ Available fields:
 | `config.postgres_version` | integer or `()` | Target PG major version, or `()` if unset |
 | `config.check_down` | bool | Whether down migrations are checked |
 | `config.disable_checks` | array | Check names that are disabled |
+
+## The `ctx` Variable
+
+`ctx` gives scripts access to per-migration metadata extracted by the framework adapter. Use it to condition on whether a migration runs inside a transaction:
+
+```rhai
+// Flag CONCURRENTLY inside a transaction — PostgreSQL will error at runtime
+if stmt.concurrent && ctx.run_in_transaction {
+    let hint = if ctx.no_transaction_hint != "" {
+        ctx.no_transaction_hint
+    } else {
+        "Run this migration outside a transaction block."
+    };
+    return #{
+        operation: "INDEX CONCURRENTLY inside a transaction",
+        problem: "CREATE INDEX CONCURRENTLY cannot run inside a transaction block.",
+        safe_alternative: hint
+    };
+}
+```
+
+Available fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ctx.run_in_transaction` | bool | Whether the migration runs inside a transaction. Defaults to `true`. |
+| `ctx.no_transaction_hint` | string | Framework-specific instruction for opting out of transactions (empty string when unavailable). |
+
+The hint is framework-specific:
+
+- **Diesel:** `"Add run_in_transaction = false to the migration's metadata.toml."`
+- **SQLx:** `"Add -- no-transaction at the top of the migration file."`
+- **`check_sql` / no framework:** empty string — provide your own fallback.
 
 ## Using `dump-ast`
 

--- a/examples/require_concurrent_index.rhai
+++ b/examples/require_concurrent_index.rhai
@@ -1,5 +1,5 @@
 // Require CONCURRENTLY on CREATE INDEX.
-// Catches: CREATE INDEX idx ON t(col);
+// Also flags CONCURRENTLY inside a transaction (PostgreSQL will error at runtime).
 // Inspect: diesel-guard dump-ast --sql "CREATE INDEX idx ON t(id);"
 
 let stmt = node.IndexStmt;
@@ -7,9 +7,24 @@ if stmt == () { return; }
 
 if !stmt.concurrent {
     let idx_name = if stmt.idxname != "" { stmt.idxname } else { "(unnamed)" };
-    #{
+    return #{
         operation: "INDEX without CONCURRENTLY: " + idx_name,
         problem: "Creating index '" + idx_name + "' without CONCURRENTLY blocks writes on the table.",
         safe_alternative: "Use CREATE INDEX CONCURRENTLY:\n  CREATE INDEX CONCURRENTLY " + idx_name + " ON ...;"
+    };
+}
+
+// CONCURRENTLY cannot run inside a transaction block
+if ctx.run_in_transaction {
+    let idx_name = if stmt.idxname != "" { stmt.idxname } else { "(unnamed)" };
+    let hint = if ctx.no_transaction_hint != "" {
+        ctx.no_transaction_hint
+    } else {
+        "Run this migration outside a transaction block."
+    };
+    #{
+        operation: "INDEX CONCURRENTLY inside a transaction: " + idx_name,
+        problem: "CREATE INDEX CONCURRENTLY cannot run inside a transaction block. PostgreSQL will raise an error at runtime.",
+        safe_alternative: hint
     }
 }

--- a/src/adapters/diesel.rs
+++ b/src/adapters/diesel.rs
@@ -9,11 +9,12 @@
 //! ```
 
 use super::{
-    MigrationAdapter, MigrationFile, Result, collect_and_sort_entries, is_single_migration_dir,
-    should_check_migration,
+    MigrationAdapter, MigrationContext, MigrationFile, Result, collect_and_sort_entries,
+    is_single_migration_dir, should_check_migration,
 };
 use camino::Utf8Path;
 use regex::Regex;
+use serde::Deserialize;
 use std::sync::LazyLock;
 
 /// Regex pattern for Diesel timestamp formats.
@@ -23,14 +24,19 @@ static DIESEL_TIMESTAMP_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         .expect("valid regex pattern")
 });
 
+const NO_TRANSACTION_HINT: &str =
+    "Create `metadata.toml` in the migration directory with `run_in_transaction = false`.";
+
 /// Diesel migration adapter.
 pub struct DieselAdapter;
 
-impl MigrationAdapter for DieselAdapter {
-    fn name(&self) -> &'static str {
-        "Diesel"
-    }
+/// Diesel metadata.toml deserialization target.
+#[derive(Deserialize, Default)]
+struct MetadataFile {
+    run_in_transaction: Option<bool>,
+}
 
+impl MigrationAdapter for DieselAdapter {
     fn collect_migration_files(
         &self,
         dir: &Utf8Path,
@@ -38,8 +44,6 @@ impl MigrationAdapter for DieselAdapter {
         check_down: bool,
     ) -> Result<Vec<MigrationFile>> {
         if is_single_migration_dir(dir) {
-            // When the user targets a specific migration directory, skip the
-            // start_after filter — they explicitly chose this migration.
             return self.process_migration_directory(dir, None, check_down);
         }
 
@@ -57,8 +61,6 @@ impl MigrationAdapter for DieselAdapter {
                 let filename = path.file_name().unwrap_or("");
                 let parsed_timestamp = self.parse_timestamp(filename);
 
-                // Apply start_after filter when the file has a valid timestamp.
-                // Files without timestamps (e.g., "migration.sql") are always checked.
                 if let Some(ref ts) = parsed_timestamp
                     && !should_check_migration(start_after, ts)
                 {
@@ -77,10 +79,7 @@ impl MigrationAdapter for DieselAdapter {
         DIESEL_TIMESTAMP_REGEX
             .captures(name)
             .and_then(|cap| cap.get(1))
-            .map(|m| {
-                // Normalize by removing separators
-                m.as_str().replace(['_', '-'], "")
-            })
+            .map(|m| m.as_str().replace(['_', '-'], ""))
     }
 
     fn validate_timestamp(&self, timestamp: &str) -> Result<()> {
@@ -91,7 +90,6 @@ impl MigrationAdapter for DieselAdapter {
             ).into());
         };
 
-        // Check if the matched part is the entire string
         if captures.get(0).unwrap().as_str() == timestamp {
             Ok(())
         } else {
@@ -99,6 +97,36 @@ impl MigrationAdapter for DieselAdapter {
                 "Invalid Diesel timestamp format: {}. Expected: YYYYMMDDHHMMSS, YYYY_MM_DD_HHMMSS, or YYYY-MM-DD-HHMMSS",
                 timestamp
             ).into())
+        }
+    }
+
+    fn extract_migration_metadata(&self, file_path: &Utf8Path) -> MigrationContext {
+        // metadata.toml lives in the same directory as the SQL file
+        let metadata_path = match file_path.parent() {
+            Some(parent) => parent.join("metadata.toml"),
+            None => {
+                return MigrationContext {
+                    run_in_transaction: true,
+                    no_transaction_hint: NO_TRANSACTION_HINT,
+                };
+            }
+        };
+
+        let content = match std::fs::read_to_string(&metadata_path) {
+            Ok(c) => c,
+            Err(_) => {
+                return MigrationContext {
+                    run_in_transaction: true,
+                    no_transaction_hint: NO_TRANSACTION_HINT,
+                };
+            }
+        };
+
+        let parsed: MetadataFile = toml::from_str(&content).unwrap_or_default();
+
+        MigrationContext {
+            run_in_transaction: parsed.run_in_transaction.unwrap_or(true),
+            no_transaction_hint: NO_TRANSACTION_HINT,
         }
     }
 }
@@ -251,6 +279,100 @@ mod tests {
             Some("20240101000000"),
             "2024-01-01-000000"
         ));
+    }
+
+    #[test]
+    fn test_extract_metadata_no_parent_defaults_to_in_transaction() {
+        let adapter = DieselAdapter;
+        let meta = adapter.extract_migration_metadata(Utf8Path::new(""));
+        assert!(meta.run_in_transaction);
+    }
+
+    #[test]
+    fn test_extract_metadata_no_file_defaults_to_in_transaction() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let sql_file = temp_dir.path().join("up.sql");
+        std::fs::write(&sql_file, "SELECT 1;").unwrap();
+        // No metadata.toml written
+
+        let adapter = DieselAdapter;
+        let path = Utf8Path::from_path(&sql_file).unwrap();
+        let meta = adapter.extract_migration_metadata(path);
+        assert!(meta.run_in_transaction);
+    }
+
+    #[test]
+    fn test_extract_metadata_run_in_transaction_false() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let sql_file = temp_dir.path().join("up.sql");
+        std::fs::write(&sql_file, "SELECT 1;").unwrap();
+        std::fs::write(
+            temp_dir.path().join("metadata.toml"),
+            "run_in_transaction = false\n",
+        )
+        .unwrap();
+
+        let adapter = DieselAdapter;
+        let path = Utf8Path::from_path(&sql_file).unwrap();
+        let meta = adapter.extract_migration_metadata(path);
+        assert!(!meta.run_in_transaction);
+    }
+
+    #[test]
+    fn test_extract_metadata_run_in_transaction_true_explicit() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let sql_file = temp_dir.path().join("up.sql");
+        std::fs::write(&sql_file, "SELECT 1;").unwrap();
+        std::fs::write(
+            temp_dir.path().join("metadata.toml"),
+            "run_in_transaction = true\n",
+        )
+        .unwrap();
+
+        let adapter = DieselAdapter;
+        let path = Utf8Path::from_path(&sql_file).unwrap();
+        let meta = adapter.extract_migration_metadata(path);
+        assert!(meta.run_in_transaction);
+    }
+
+    #[test]
+    fn test_extract_metadata_empty_toml_defaults_to_in_transaction() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let sql_file = temp_dir.path().join("up.sql");
+        std::fs::write(&sql_file, "SELECT 1;").unwrap();
+        std::fs::write(temp_dir.path().join("metadata.toml"), "").unwrap();
+
+        let adapter = DieselAdapter;
+        let path = Utf8Path::from_path(&sql_file).unwrap();
+        let meta = adapter.extract_migration_metadata(path);
+        assert!(meta.run_in_transaction);
+    }
+
+    #[test]
+    fn test_extract_metadata_malformed_toml_defaults_to_in_transaction() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let sql_file = temp_dir.path().join("up.sql");
+        std::fs::write(&sql_file, "SELECT 1;").unwrap();
+        std::fs::write(
+            temp_dir.path().join("metadata.toml"),
+            "this is not valid toml ][[\n",
+        )
+        .unwrap();
+
+        let adapter = DieselAdapter;
+        let path = Utf8Path::from_path(&sql_file).unwrap();
+        let meta = adapter.extract_migration_metadata(path);
+        assert!(meta.run_in_transaction);
     }
 
     #[test]

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -19,6 +19,26 @@ pub use sqlx::SqlxAdapter;
 /// Result type for adapter operations.
 pub type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
+/// Per-migration context extracted by the adapter and passed to each check.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct MigrationContext {
+    /// Whether the migration runs inside a transaction.
+    /// Defaults to `true` (most migrations run in a transaction).
+    pub run_in_transaction: bool,
+    /// Framework-specific hint for how to opt out of transactions.
+    /// Empty string when no framework context is available (e.g. `check_sql`).
+    pub no_transaction_hint: &'static str,
+}
+
+impl Default for MigrationContext {
+    fn default() -> Self {
+        Self {
+            run_in_transaction: true,
+            no_transaction_hint: "",
+        }
+    }
+}
+
 /// Represents a single migration file to check.
 #[derive(Debug, Clone)]
 pub struct MigrationFile {
@@ -39,9 +59,6 @@ impl MigrationFile {
 /// Each framework (Diesel, SQLx, etc.) implements this trait to provide
 /// framework-specific behavior for discovering, parsing, and validating migrations.
 pub trait MigrationAdapter: Send + Sync {
-    /// Framework name for display/logging.
-    fn name(&self) -> &'static str;
-
     /// Collect migration files from a directory.
     ///
     /// # Arguments
@@ -69,6 +86,13 @@ pub trait MigrationAdapter: Send + Sync {
     /// Returns an error if the timestamp doesn't match the framework's
     /// expected format.
     fn validate_timestamp(&self, timestamp: &str) -> Result<()>;
+
+    /// Extract migration context for a specific SQL file.
+    ///
+    /// Implementations read framework-specific metadata (e.g., `metadata.toml`
+    /// for Diesel, `-- no-transaction` directive for SQLx) and return it as
+    /// a `MigrationContext`.
+    fn extract_migration_metadata(&self, file_path: &Utf8Path) -> MigrationContext;
 }
 
 /// Check if migration should be checked based on start_after filter.

--- a/src/adapters/sqlx.rs
+++ b/src/adapters/sqlx.rs
@@ -6,7 +6,8 @@
 //!
 
 use super::{
-    MigrationAdapter, MigrationFile, Result, collect_and_sort_entries, should_check_migration,
+    MigrationAdapter, MigrationContext, MigrationFile, Result, collect_and_sort_entries,
+    should_check_migration,
 };
 use camino::Utf8Path;
 use regex::Regex;
@@ -19,14 +20,13 @@ use std::sync::LazyLock;
 static SQLX_VERSION_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(\d+)(_|\.)?").expect("valid regex pattern"));
 
+const NO_TRANSACTION_HINT: &str =
+    "Add `-- no-transaction` as the first line of the migration file.";
+
 /// SQLx migration adapter.
 pub struct SqlxAdapter;
 
 impl MigrationAdapter for SqlxAdapter {
-    fn name(&self) -> &'static str {
-        "SQLx"
-    }
-
     fn collect_migration_files(
         &self,
         dir: &Utf8Path,
@@ -65,6 +65,28 @@ impl MigrationAdapter for SqlxAdapter {
                 timestamp
             )
             .into())
+        }
+    }
+
+    fn extract_migration_metadata(&self, file_path: &Utf8Path) -> MigrationContext {
+        let content = match std::fs::read_to_string(file_path) {
+            Ok(c) => c,
+            Err(_) => {
+                return MigrationContext {
+                    run_in_transaction: true,
+                    no_transaction_hint: NO_TRANSACTION_HINT,
+                };
+            }
+        };
+
+        // Scan every line for `-- no-transaction` (case-insensitive, trimmed)
+        let has_no_transaction = content
+            .lines()
+            .any(|line| line.trim().eq_ignore_ascii_case("-- no-transaction"));
+
+        MigrationContext {
+            run_in_transaction: !has_no_transaction,
+            no_transaction_hint: NO_TRANSACTION_HINT,
         }
     }
 }
@@ -228,6 +250,74 @@ mod tests {
         assert!(should_check_migration(Some("1"), "2"));
         assert!(!should_check_migration(Some("10"), "2"));
         assert!(!should_check_migration(Some("5"), "5"));
+    }
+
+    #[test]
+    fn test_extract_metadata_unreadable_file_defaults_to_in_transaction() {
+        let adapter = SqlxAdapter;
+        let path = Utf8Path::new("/nonexistent/path/migration.sql");
+        let meta = adapter.extract_migration_metadata(path);
+        assert!(meta.run_in_transaction);
+    }
+
+    #[test]
+    fn test_extract_metadata_no_directive_defaults_to_in_transaction() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let sql_file = temp_dir.path().join("20240101000000_add_index.sql");
+        fs::write(&sql_file, "CREATE INDEX idx ON users(email);\n").unwrap();
+
+        let adapter = SqlxAdapter;
+        let path = Utf8Path::from_path(&sql_file).unwrap();
+        let meta = adapter.extract_migration_metadata(path);
+        assert!(meta.run_in_transaction);
+    }
+
+    #[test]
+    fn test_extract_metadata_with_no_transaction_directive() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let sql_file = temp_dir.path().join("20240101000000_add_index.sql");
+        fs::write(
+            &sql_file,
+            "-- no-transaction\nCREATE INDEX CONCURRENTLY idx ON users(email);\n",
+        )
+        .unwrap();
+
+        let adapter = SqlxAdapter;
+        let path = Utf8Path::from_path(&sql_file).unwrap();
+        let meta = adapter.extract_migration_metadata(path);
+        assert!(!meta.run_in_transaction);
+    }
+
+    #[test]
+    fn test_extract_metadata_directive_case_insensitive() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let sql_file = temp_dir.path().join("20240101000000_add_index.sql");
+        fs::write(&sql_file, "-- NO-TRANSACTION\nSELECT 1;\n").unwrap();
+
+        let adapter = SqlxAdapter;
+        let path = Utf8Path::from_path(&sql_file).unwrap();
+        let meta = adapter.extract_migration_metadata(path);
+        assert!(!meta.run_in_transaction);
+    }
+
+    #[test]
+    fn test_extract_metadata_directive_anywhere_in_file() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let sql_file = temp_dir.path().join("20240101000000_add_index.sql");
+        fs::write(&sql_file, "SELECT 1;\n-- no-transaction\nSELECT 2;\n").unwrap();
+
+        let adapter = SqlxAdapter;
+        let path = Utf8Path::from_path(&sql_file).unwrap();
+        let meta = adapter.extract_migration_metadata(path);
+        assert!(!meta.run_in_transaction);
     }
 
     #[test]

--- a/src/checks/add_column.rs
+++ b/src/checks/add_column.rs
@@ -15,14 +15,14 @@ use crate::checks::pg_helpers::{
     ConstrType, NodeEnum, alter_table_cmds, cmd_def_as_column_def, column_has_constraint,
     column_type_name,
 };
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 use pg_query::protobuf::ColumnDef;
 
 pub struct AddColumnCheck;
 
 impl Check for AddColumnCheck {
-    fn check(&self, node: &NodeEnum, config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let Some((table_name, cmds)) = alter_table_cmds(node) else {
             return vec![];
         };

--- a/src/checks/add_index.rs
+++ b/src/checks/add_index.rs
@@ -11,20 +11,16 @@
 //! though it takes longer and cannot be run inside a transaction block.
 
 use crate::checks::pg_helpers::{NodeEnum, range_var_name};
-use crate::checks::{Check, Config, unique_prefix};
+use crate::checks::{Check, Config, MigrationContext, unique_prefix};
 use crate::violation::Violation;
 
 pub struct AddIndexCheck;
 
 impl Check for AddIndexCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, ctx: &MigrationContext) -> Vec<Violation> {
         let NodeEnum::IndexStmt(index_stmt) = node else {
             return vec![];
         };
-
-        if index_stmt.concurrent {
-            return vec![];
-        }
 
         let table_name = index_stmt
             .relation
@@ -38,42 +34,49 @@ impl Check for AddIndexCheck {
         };
         let unique_str = unique_prefix(index_stmt.unique);
 
-        vec![Violation::new(
-            "ADD INDEX without CONCURRENTLY",
-            format!(
-                "Creating {unique}index '{index}' on table '{table}' without CONCURRENTLY acquires a SHARE lock, blocking writes \
-                (INSERT, UPDATE, DELETE). Duration depends on table size. Reads are still allowed.",
-                unique = unique_str,
-                index = index_name,
-                table = table_name
-            ),
-            format!(
-                r#"Use CONCURRENTLY to build the index without blocking writes:
+        if !index_stmt.concurrent {
+            // CREATE INDEX without CONCURRENTLY — always a violation
+            return vec![Violation::new(
+                "ADD INDEX without CONCURRENTLY",
+                format!(
+                    "Creating {unique}index '{index}' on table '{table}' without CONCURRENTLY acquires a SHARE lock, blocking writes \
+                    (INSERT, UPDATE, DELETE). Duration depends on table size. Reads are still allowed.",
+                    unique = unique_str,
+                    index = index_name,
+                    table = table_name
+                ),
+                format!(
+                    r#"Use CONCURRENTLY to build the index without blocking writes:
    CREATE {unique}INDEX CONCURRENTLY {index} ON {table};
 
 Note: CONCURRENTLY takes longer and uses more resources, but allows concurrent INSERT, UPDATE, and DELETE operations. The index build may fail if there are deadlocks or unique constraint violations.
 
-For Diesel migrations:
-1. Create metadata.toml in your migration directory:
-   run_in_transaction = false
-
-2. Use CREATE INDEX CONCURRENTLY in your up.sql:
-   CREATE {unique}INDEX CONCURRENTLY {index} ON {table}(...);
-
-For SQLx migrations:
-1. Add the no-transaction directive at the top of your migration file:
-   -- no-transaction
-
-2. Use CREATE INDEX CONCURRENTLY:
-   CREATE {unique}INDEX CONCURRENTLY {index} ON {table}(...);
-
 Considerations:
 - Requires more total work and takes longer to complete
 - If it fails, it leaves behind an "invalid" index that should be dropped"#,
+                    unique = unique_str,
+                    index = index_name,
+                    table = table_name,
+                ),
+            )];
+        }
+
+        // CREATE INDEX CONCURRENTLY — safe only if migration runs outside a transaction
+        if !ctx.run_in_transaction {
+            return vec![];
+        }
+
+        // CREATE INDEX CONCURRENTLY inside a transaction — PostgreSQL will error at runtime
+        vec![Violation::new(
+            "CREATE INDEX CONCURRENTLY inside a transaction",
+            format!(
+                "Creating {unique}index '{index}' on table '{table}' with CONCURRENTLY cannot run inside a transaction block. \
+                PostgreSQL will raise an error at runtime.",
                 unique = unique_str,
                 index = index_name,
                 table = table_name
             ),
+            ctx.no_transaction_hint,
         )]
     }
 }
@@ -81,7 +84,8 @@ Considerations:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{assert_allows, assert_detects_violation, assert_detects_violation_containing};
+    use crate::checks::test_utils::parse_sql;
+    use crate::{assert_detects_violation, assert_detects_violation_containing};
 
     #[test]
     fn test_detects_create_index_without_concurrently() {
@@ -103,23 +107,114 @@ mod tests {
     }
 
     #[test]
-    fn test_allows_create_index_with_concurrently() {
-        assert_allows!(
-            AddIndexCheck,
-            "CREATE INDEX CONCURRENTLY idx_users_email ON users(email);"
+    fn test_allows_create_index_with_concurrently_outside_transaction() {
+        let stmt = parse_sql("CREATE INDEX CONCURRENTLY idx_users_email ON users(email);");
+        let violations = AddIndexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: false,
+                ..MigrationContext::default()
+            },
+        );
+        assert_eq!(
+            violations.len(),
+            0,
+            "Expected no violations outside transaction"
         );
     }
 
     #[test]
-    fn test_allows_create_unique_index_with_concurrently() {
-        assert_allows!(
-            AddIndexCheck,
-            "CREATE UNIQUE INDEX CONCURRENTLY idx_users_email ON users(email);"
+    fn test_allows_create_unique_index_with_concurrently_outside_transaction() {
+        let stmt = parse_sql("CREATE UNIQUE INDEX CONCURRENTLY idx_users_email ON users(email);");
+        let violations = AddIndexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: false,
+                ..MigrationContext::default()
+            },
         );
+        assert_eq!(
+            violations.len(),
+            0,
+            "Expected no violations outside transaction"
+        );
+    }
+
+    #[test]
+    fn test_detects_concurrent_in_transaction() {
+        let stmt = parse_sql("CREATE INDEX CONCURRENTLY idx_users_email ON users(email);");
+        let violations = AddIndexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: true,
+                ..MigrationContext::default()
+            },
+        );
+        assert_eq!(violations.len(), 1, "Expected 1 violation");
+        assert_eq!(
+            violations[0].operation,
+            "CREATE INDEX CONCURRENTLY inside a transaction"
+        );
+    }
+
+    #[test]
+    fn test_allows_concurrent_outside_transaction() {
+        let stmt = parse_sql("CREATE INDEX CONCURRENTLY idx_users_email ON users(email);");
+        let violations = AddIndexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: false,
+                ..MigrationContext::default()
+            },
+        );
+        assert_eq!(violations.len(), 0, "Expected no violations");
     }
 
     #[test]
     fn test_ignores_other_statements() {
-        assert_allows!(AddIndexCheck, "CREATE TABLE users (id SERIAL PRIMARY KEY);");
+        let stmt = parse_sql("CREATE TABLE users (id SERIAL PRIMARY KEY);");
+        let violations =
+            AddIndexCheck.check(&stmt, &Config::default(), &MigrationContext::default());
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_sqlx_framework_safe_alternative_message() {
+        let stmt = parse_sql("CREATE INDEX CONCURRENTLY idx_users_email ON users(email);");
+        let violations = AddIndexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: true,
+                no_transaction_hint: "Add `-- no-transaction` as the first line of the migration file.",
+            },
+        );
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0].safe_alternative.contains("-- no-transaction"),
+            "Expected SQLx safe alternative message"
+        );
+    }
+
+    #[test]
+    fn test_diesel_framework_safe_alternative_message() {
+        let stmt = parse_sql("CREATE INDEX CONCURRENTLY idx_users_email ON users(email);");
+        let violations = AddIndexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: true,
+                no_transaction_hint: "Create `metadata.toml` in the migration directory with `run_in_transaction = false`.",
+            },
+        );
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0].safe_alternative.contains("metadata.toml"),
+            "Expected Diesel safe alternative message"
+        );
     }
 }

--- a/src/checks/add_json_column.rs
+++ b/src/checks/add_json_column.rs
@@ -14,13 +14,13 @@
 use crate::checks::pg_helpers::{
     NodeEnum, alter_table_cmds, cmd_def_as_column_def, column_type_name, is_json_type,
 };
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 pub struct AddJsonColumnCheck;
 
 impl Check for AddJsonColumnCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let Some((table_name, cmds)) = alter_table_cmds(node) else {
             return vec![];
         };

--- a/src/checks/add_not_null.rs
+++ b/src/checks/add_not_null.rs
@@ -11,13 +11,13 @@
 //! separately, then add the NOT NULL constraint.
 
 use crate::checks::pg_helpers::{AlterTableType, NodeEnum, alter_table_cmds};
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 pub struct AddNotNullCheck;
 
 impl Check for AddNotNullCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let Some((table_name, cmds)) = alter_table_cmds(node) else {
             return vec![];
         };

--- a/src/checks/add_primary_key.rs
+++ b/src/checks/add_primary_key.rs
@@ -14,13 +14,13 @@
 use crate::checks::pg_helpers::{
     ConstrType, NodeEnum, alter_table_cmds, cmd_def_as_constraint, constraint_columns_str,
 };
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 pub struct AddPrimaryKeyCheck;
 
 impl Check for AddPrimaryKeyCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let Some((table_name, cmds)) = alter_table_cmds(node) else {
             return vec![];
         };

--- a/src/checks/add_serial_column.rs
+++ b/src/checks/add_serial_column.rs
@@ -14,13 +14,13 @@
 use crate::checks::pg_helpers::{
     NodeEnum, alter_table_cmds, cmd_def_as_column_def, column_type_name, is_serial_pattern,
 };
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 pub struct AddSerialColumnCheck;
 
 impl Check for AddSerialColumnCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let Some((table_name, cmds)) = alter_table_cmds(node) else {
             return vec![];
         };

--- a/src/checks/add_unique_constraint.rs
+++ b/src/checks/add_unique_constraint.rs
@@ -12,13 +12,13 @@
 use crate::checks::pg_helpers::{
     ConstrType, NodeEnum, alter_table_cmds, cmd_def_as_constraint, constraint_columns_str,
 };
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 pub struct AddUniqueConstraintCheck;
 
 impl Check for AddUniqueConstraintCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let Some((table_name, cmds)) = alter_table_cmds(node) else {
             return vec![];
         };

--- a/src/checks/alter_column_type.rs
+++ b/src/checks/alter_column_type.rs
@@ -12,13 +12,13 @@
 use crate::checks::pg_helpers::{
     AlterTableType, NodeEnum, alter_table_cmds, cmd_def_as_column_def, column_type_name,
 };
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 pub struct AlterColumnTypeCheck;
 
 impl Check for AlterColumnTypeCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let Some((table_name, cmds)) = alter_table_cmds(node) else {
             return vec![];
         };

--- a/src/checks/char_type.rs
+++ b/src/checks/char_type.rs
@@ -22,13 +22,13 @@ use crate::checks::pg_helpers::{
     ColumnDef, NodeEnum, alter_table_cmds, cmd_def_as_column_def, column_type_name,
     for_each_column_def, is_char_type,
 };
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 pub struct CharTypeCheck;
 
 impl Check for CharTypeCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         // Handle CREATE TABLE via for_each_column_def
         if let NodeEnum::CreateStmt(_) = node {
             return for_each_column_def(node)

--- a/src/checks/create_extension.rs
+++ b/src/checks/create_extension.rs
@@ -11,13 +11,13 @@
 //! (Ansible, Terraform, etc.) with appropriate privileges before running migrations.
 
 use crate::checks::pg_helpers::NodeEnum;
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 pub struct CreateExtensionCheck;
 
 impl Check for CreateExtensionCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let NodeEnum::CreateExtensionStmt(ext) = node else {
             return vec![];
         };

--- a/src/checks/drop_column.rs
+++ b/src/checks/drop_column.rs
@@ -12,13 +12,13 @@
 //! in application code, deploy without references, and drop in a later migration.
 
 use crate::checks::pg_helpers::{AlterTableType, NodeEnum, alter_table_cmds};
-use crate::checks::{Check, Config, if_exists_clause};
+use crate::checks::{Check, Config, MigrationContext, if_exists_clause};
 use crate::violation::Violation;
 
 pub struct DropColumnCheck;
 
 impl Check for DropColumnCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let Some((table_name, cmds)) = alter_table_cmds(node) else {
             return vec![];
         };

--- a/src/checks/drop_database.rs
+++ b/src/checks/drop_database.rs
@@ -18,13 +18,13 @@
 //! automation or DBA operations, not application migrations.
 
 use crate::checks::pg_helpers::NodeEnum;
-use crate::checks::{Check, Config, if_exists_clause};
+use crate::checks::{Check, Config, MigrationContext, if_exists_clause};
 use crate::violation::Violation;
 
 pub struct DropDatabaseCheck;
 
 impl Check for DropDatabaseCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let NodeEnum::DropdbStmt(drop_db) = node else {
             return vec![];
         };

--- a/src/checks/drop_index.rs
+++ b/src/checks/drop_index.rs
@@ -11,13 +11,13 @@
 //! concurrent queries, though it takes longer and cannot be run inside a transaction block.
 
 use crate::checks::pg_helpers::{NodeEnum, ObjectType, drop_object_names};
-use crate::checks::{Check, Config, if_exists_clause};
+use crate::checks::{Check, Config, MigrationContext, if_exists_clause};
 use crate::violation::Violation;
 
 pub struct DropIndexCheck;
 
 impl Check for DropIndexCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, ctx: &MigrationContext) -> Vec<Violation> {
         let NodeEnum::DropStmt(drop_stmt) = node else {
             return vec![];
         };
@@ -26,51 +26,57 @@ impl Check for DropIndexCheck {
             return vec![];
         }
 
-        // DROP INDEX CONCURRENTLY is safe, skip it
-        if drop_stmt.concurrent {
-            return vec![];
-        }
-
         let if_exists_str = if_exists_clause(drop_stmt.missing_ok);
 
-        drop_object_names(&drop_stmt.objects)
-            .into_iter()
-            .map(|name| {
-                Violation::new(
-                    "DROP INDEX without CONCURRENTLY",
-                    format!(
-                        "Dropping index '{index}'{if_exists} without CONCURRENTLY acquires an ACCESS EXCLUSIVE lock, blocking all \
-                        queries (SELECT, INSERT, UPDATE, DELETE) on the table until complete. Duration depends on system load and concurrent transactions.",
-                        index = name,
-                        if_exists = if_exists_str
-                    ),
-                    format!(r#"Use CONCURRENTLY to drop the index without blocking queries:
+        if !drop_stmt.concurrent {
+            // DROP INDEX without CONCURRENTLY — always a violation
+            return drop_object_names(&drop_stmt.objects)
+                .into_iter()
+                .map(|name| {
+                    Violation::new(
+                        "DROP INDEX without CONCURRENTLY",
+                        format!(
+                            "Dropping index '{index}'{if_exists} without CONCURRENTLY acquires an ACCESS EXCLUSIVE lock, blocking all \
+                            queries (SELECT, INSERT, UPDATE, DELETE) on the table until complete. Duration depends on system load and concurrent transactions.",
+                            index = name,
+                            if_exists = if_exists_str
+                        ),
+                        format!(r#"Use CONCURRENTLY to drop the index without blocking queries:
    DROP INDEX CONCURRENTLY{if_exists} {index};
 
 Note: CONCURRENTLY requires Postgres 9.2+ and cannot be run inside a transaction block.
-
-For Diesel migrations:
-1. Create metadata.toml in your migration directory:
-   run_in_transaction = false
-
-2. Use DROP INDEX CONCURRENTLY in your up.sql:
-   DROP INDEX CONCURRENTLY{if_exists} {index};
-
-For SQLx migrations:
-1. Add the no-transaction directive at the top of your migration file:
-   -- no-transaction
-
-2. Use DROP INDEX CONCURRENTLY:
-   DROP INDEX CONCURRENTLY{if_exists} {index};
 
 Considerations:
 - Takes longer to complete than regular DROP INDEX
 - Allows concurrent SELECT, INSERT, UPDATE, DELETE operations
 - If it fails, the index may be marked "invalid" and should be dropped again
 - Cannot be rolled back (no transaction support)"#,
-                        if_exists = if_exists_str,
-                        index = name
+                            if_exists = if_exists_str,
+                            index = name,
+                        ),
+                    )
+                })
+                .collect();
+        }
+
+        // DROP INDEX CONCURRENTLY — safe only if migration runs outside a transaction
+        if !ctx.run_in_transaction {
+            return vec![];
+        }
+
+        // DROP INDEX CONCURRENTLY inside a transaction — PostgreSQL will error at runtime
+        drop_object_names(&drop_stmt.objects)
+            .into_iter()
+            .map(|name| {
+                Violation::new(
+                    "DROP INDEX CONCURRENTLY inside a transaction",
+                    format!(
+                        "Dropping index '{index}'{if_exists} with CONCURRENTLY cannot run inside a transaction block. \
+                        PostgreSQL will raise an error at runtime.",
+                        index = name,
+                        if_exists = if_exists_str
                     ),
+                    ctx.no_transaction_hint,
                 )
             })
             .collect()
@@ -80,6 +86,7 @@ Considerations:
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::checks::test_utils::parse_sql;
     use crate::{assert_allows, assert_detects_n_violations, assert_detects_violation};
 
     #[test]
@@ -138,8 +145,53 @@ mod tests {
     }
 
     #[test]
-    fn test_allows_drop_index_concurrently() {
-        assert_allows!(DropIndexCheck, "DROP INDEX CONCURRENTLY idx_users_email;");
+    fn test_allows_drop_index_concurrently_outside_transaction() {
+        let stmt = parse_sql("DROP INDEX CONCURRENTLY idx_users_email;");
+        let violations = DropIndexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: false,
+                ..MigrationContext::default()
+            },
+        );
+        assert_eq!(
+            violations.len(),
+            0,
+            "Expected no violations outside transaction"
+        );
+    }
+
+    #[test]
+    fn test_detects_concurrent_in_transaction() {
+        let stmt = parse_sql("DROP INDEX CONCURRENTLY idx_users_email;");
+        let violations = DropIndexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: true,
+                ..MigrationContext::default()
+            },
+        );
+        assert_eq!(violations.len(), 1, "Expected 1 violation");
+        assert_eq!(
+            violations[0].operation,
+            "DROP INDEX CONCURRENTLY inside a transaction"
+        );
+    }
+
+    #[test]
+    fn test_allows_concurrent_outside_transaction() {
+        let stmt = parse_sql("DROP INDEX CONCURRENTLY idx_users_email;");
+        let violations = DropIndexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: false,
+                ..MigrationContext::default()
+            },
+        );
+        assert_eq!(violations.len(), 0, "Expected no violations");
     }
 
     #[test]
@@ -152,6 +204,42 @@ mod tests {
         assert_allows!(
             DropIndexCheck,
             "CREATE INDEX idx_users_email ON users(email);"
+        );
+    }
+
+    #[test]
+    fn test_sqlx_framework_safe_alternative_message() {
+        let stmt = parse_sql("DROP INDEX CONCURRENTLY idx_users_email;");
+        let violations = DropIndexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: true,
+                no_transaction_hint: "Add `-- no-transaction` as the first line of the migration file.",
+            },
+        );
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0].safe_alternative.contains("-- no-transaction"),
+            "Expected SQLx safe alternative message"
+        );
+    }
+
+    #[test]
+    fn test_diesel_framework_safe_alternative_message() {
+        let stmt = parse_sql("DROP INDEX CONCURRENTLY idx_users_email;");
+        let violations = DropIndexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: true,
+                no_transaction_hint: "Create `metadata.toml` in the migration directory with `run_in_transaction = false`.",
+            },
+        );
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0].safe_alternative.contains("metadata.toml"),
+            "Expected Diesel safe alternative message"
         );
     }
 }

--- a/src/checks/drop_primary_key.rs
+++ b/src/checks/drop_primary_key.rs
@@ -14,7 +14,7 @@
 //! connections to verify constraint types with certainty.
 
 use crate::checks::pg_helpers::{AlterTableType, NodeEnum, alter_table_cmds};
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 use regex::Regex;
 use std::sync::LazyLock;
@@ -39,7 +39,7 @@ impl DropPrimaryKeyCheck {
 }
 
 impl Check for DropPrimaryKeyCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let Some((table_name, cmds)) = alter_table_cmds(node) else {
             return vec![];
         };

--- a/src/checks/drop_table.rs
+++ b/src/checks/drop_table.rs
@@ -12,13 +12,13 @@
 //! backups exist, and check for foreign key dependencies before dropping.
 
 use crate::checks::pg_helpers::{DropBehavior, NodeEnum, ObjectType, drop_object_names};
-use crate::checks::{Check, Config, if_exists_clause};
+use crate::checks::{Check, Config, MigrationContext, if_exists_clause};
 use crate::violation::Violation;
 
 pub struct DropTableCheck;
 
 impl Check for DropTableCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let NodeEnum::DropStmt(drop_stmt) = node else {
             return vec![];
         };

--- a/src/checks/generated_column.rs
+++ b/src/checks/generated_column.rs
@@ -18,13 +18,13 @@ use crate::checks::pg_helpers::{
     ConstrType, NodeEnum, alter_table_cmds, cmd_def_as_column_def, column_has_constraint,
     column_type_name,
 };
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 pub struct GeneratedColumnCheck;
 
 impl Check for GeneratedColumnCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let Some((table_name, cmds)) = alter_table_cmds(node) else {
             return vec![];
         };

--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -74,6 +74,8 @@ use pg_helpers::{NodeEnum, extract_node};
 use pg_query::protobuf::RawStmt;
 use std::sync::LazyLock;
 
+pub use crate::adapters::MigrationContext;
+
 /// Lazily-derived list of all built-in check names from an unfiltered registry.
 /// This avoids maintaining a manual list that can drift from the actual checks.
 static BUILTIN_CHECK_NAMES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
@@ -91,7 +93,7 @@ pub trait Check: Send + Sync {
     }
 
     /// Run the check on a pg_query AST node and return any violations found
-    fn check(&self, node: &NodeEnum, config: &Config) -> Vec<Violation>;
+    fn check(&self, node: &NodeEnum, config: &Config, ctx: &MigrationContext) -> Vec<Violation>;
 }
 
 /// Registry of all available checks
@@ -159,10 +161,15 @@ impl Registry {
     }
 
     /// Check a single AST node against all registered checks
-    pub fn check_node(&self, node: &NodeEnum, config: &Config) -> Vec<Violation> {
+    pub fn check_node(
+        &self,
+        node: &NodeEnum,
+        config: &Config,
+        ctx: &MigrationContext,
+    ) -> Vec<Violation> {
         self.checks
             .iter()
-            .flat_map(|check| check.check(node, config))
+            .flat_map(|check| check.check(node, config, ctx))
             .collect()
     }
 
@@ -176,6 +183,7 @@ impl Registry {
         sql: &str,
         ignore_ranges: &[IgnoreRange],
         config: &Config,
+        ctx: &MigrationContext,
     ) -> Vec<Violation> {
         // Build set of all ignored line numbers for fast lookup
         let ignored_lines: std::collections::HashSet<usize> = ignore_ranges
@@ -199,7 +207,7 @@ impl Registry {
             let stmt_line = byte_offset_to_line(sql, offset);
 
             if !ignored_lines.contains(&stmt_line) {
-                violations.extend(self.check_node(node, config));
+                violations.extend(self.check_node(node, config, ctx));
             }
         }
 
@@ -328,6 +336,7 @@ ALTER TABLE users DROP COLUMN email;
             sql,
             &ignore_ranges,
             &Config::default(),
+            &MigrationContext::default(),
         );
         assert_eq!(violations.len(), 0);
     }
@@ -345,6 +354,7 @@ ALTER TABLE users DROP COLUMN email;
             sql,
             &ignore_ranges,
             &Config::default(),
+            &MigrationContext::default(),
         );
         assert_eq!(violations.len(), 1);
     }

--- a/src/checks/reindex.rs
+++ b/src/checks/reindex.rs
@@ -12,7 +12,7 @@
 //! inside a transaction block.
 
 use crate::checks::pg_helpers::{Node, NodeEnum};
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 pub struct ReindexCheck;
@@ -38,7 +38,7 @@ fn has_concurrently(params: &[Node]) -> bool {
 }
 
 impl Check for ReindexCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, ctx: &MigrationContext) -> Vec<Violation> {
         let NodeEnum::ReindexStmt(reindex) = node else {
             return vec![];
         };
@@ -47,10 +47,6 @@ impl Check for ReindexCheck {
             // SYSTEM (kind=4) or unknown -- skip
             return vec![];
         };
-
-        if has_concurrently(&reindex.params) {
-            return vec![];
-        }
 
         // Determine target name based on kind
         let target = match reindex.kind {
@@ -69,39 +65,43 @@ impl Check for ReindexCheck {
             _ => String::new(),
         };
 
-        vec![Violation::new(
-            "REINDEX without CONCURRENTLY",
-            format!(
-                "REINDEX {object} '{target}' without CONCURRENTLY acquires an ACCESS EXCLUSIVE lock, \
-                blocking all operations on the {object} '{target}' until complete. Duration depends on index size.",
-            ),
-            format!(
-                r#"Use REINDEX CONCURRENTLY for lock-free reindexing (Postgres 12+):
+        if !has_concurrently(&reindex.params) {
+            // REINDEX without CONCURRENTLY — always a violation
+            return vec![Violation::new(
+                "REINDEX without CONCURRENTLY",
+                format!(
+                    "REINDEX {object} '{target}' without CONCURRENTLY acquires an ACCESS EXCLUSIVE lock, \
+                    blocking all operations on the {object} '{target}' until complete. Duration depends on index size.",
+                ),
+                format!(
+                    r#"Use REINDEX CONCURRENTLY for lock-free reindexing (Postgres 12+):
 
    REINDEX {object} CONCURRENTLY {target};
 
 Note: CONCURRENTLY requires Postgres 12+ and cannot be run inside a transaction block.
-
-For Diesel migrations:
-1. Create metadata.toml in your migration directory:
-   run_in_transaction = false
-
-2. Use REINDEX CONCURRENTLY in your up.sql:
-   REINDEX {object} CONCURRENTLY {target};
-
-For SQLx migrations:
-1. Add the no-transaction directive at the top of your migration file:
-   -- no-transaction
-
-2. Use REINDEX CONCURRENTLY:
-   REINDEX {object} CONCURRENTLY {target};
 
 Considerations:
 - Takes longer to complete than regular REINDEX
 - Allows concurrent read/write operations
 - If it fails, the index may be left in "invalid" state and need manual cleanup
 - Cannot be rolled back (no transaction support)"#,
+                ),
+            )];
+        }
+
+        // REINDEX CONCURRENTLY — safe only if migration runs outside a transaction
+        if !ctx.run_in_transaction {
+            return vec![];
+        }
+
+        // REINDEX CONCURRENTLY inside a transaction — PostgreSQL will error at runtime
+        vec![Violation::new(
+            "REINDEX CONCURRENTLY inside a transaction",
+            format!(
+                "REINDEX {object} CONCURRENTLY '{target}' cannot run inside a transaction block. \
+                PostgreSQL will raise an error at runtime.",
             ),
+            ctx.no_transaction_hint,
         )]
     }
 }
@@ -109,7 +109,8 @@ Considerations:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{assert_allows, assert_detects_violation, assert_detects_violation_containing};
+    use crate::checks::test_utils::parse_sql;
+    use crate::{assert_detects_violation, assert_detects_violation_containing};
 
     #[test]
     fn test_detects_reindex_index() {
@@ -148,13 +149,71 @@ mod tests {
     }
 
     #[test]
-    fn test_allows_reindex_index_concurrently() {
-        assert_allows!(ReindexCheck, "REINDEX INDEX CONCURRENTLY idx_users_email;");
+    fn test_allows_reindex_index_concurrently_outside_transaction() {
+        let stmt = parse_sql("REINDEX INDEX CONCURRENTLY idx_users_email;");
+        let violations = ReindexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: false,
+                ..MigrationContext::default()
+            },
+        );
+        assert_eq!(
+            violations.len(),
+            0,
+            "Expected no violations outside transaction"
+        );
     }
 
     #[test]
-    fn test_allows_reindex_table_concurrently() {
-        assert_allows!(ReindexCheck, "REINDEX TABLE CONCURRENTLY users;");
+    fn test_allows_reindex_table_concurrently_outside_transaction() {
+        let stmt = parse_sql("REINDEX TABLE CONCURRENTLY users;");
+        let violations = ReindexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: false,
+                ..MigrationContext::default()
+            },
+        );
+        assert_eq!(
+            violations.len(),
+            0,
+            "Expected no violations outside transaction"
+        );
+    }
+
+    #[test]
+    fn test_detects_concurrent_in_transaction() {
+        let stmt = parse_sql("REINDEX INDEX CONCURRENTLY idx_users_email;");
+        let violations = ReindexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: true,
+                ..MigrationContext::default()
+            },
+        );
+        assert_eq!(violations.len(), 1, "Expected 1 violation");
+        assert_eq!(
+            violations[0].operation,
+            "REINDEX CONCURRENTLY inside a transaction"
+        );
+    }
+
+    #[test]
+    fn test_allows_concurrent_outside_transaction() {
+        let stmt = parse_sql("REINDEX INDEX CONCURRENTLY idx_users_email;");
+        let violations = ReindexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: false,
+                ..MigrationContext::default()
+            },
+        );
+        assert_eq!(violations.len(), 0, "Expected no violations");
     }
 
     #[test]
@@ -181,8 +240,52 @@ mod tests {
 
     #[test]
     fn test_ignores_other_statements() {
-        assert_allows!(ReindexCheck, "CREATE INDEX idx_test ON users(email);");
-        assert_allows!(ReindexCheck, "DROP INDEX idx_test;");
-        assert_allows!(ReindexCheck, "ALTER TABLE users ADD COLUMN email TEXT;");
+        let ctx = MigrationContext::default();
+        let config = Config::default();
+
+        let stmt = parse_sql("CREATE INDEX idx_test ON users(email);");
+        assert_eq!(ReindexCheck.check(&stmt, &config, &ctx).len(), 0);
+
+        let stmt = parse_sql("DROP INDEX idx_test;");
+        assert_eq!(ReindexCheck.check(&stmt, &config, &ctx).len(), 0);
+
+        let stmt = parse_sql("ALTER TABLE users ADD COLUMN email TEXT;");
+        assert_eq!(ReindexCheck.check(&stmt, &config, &ctx).len(), 0);
+    }
+
+    #[test]
+    fn test_sqlx_framework_safe_alternative_message() {
+        let stmt = parse_sql("REINDEX INDEX CONCURRENTLY idx_users_email;");
+        let violations = ReindexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: true,
+                no_transaction_hint: "Add `-- no-transaction` as the first line of the migration file.",
+            },
+        );
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0].safe_alternative.contains("-- no-transaction"),
+            "Expected SQLx safe alternative message"
+        );
+    }
+
+    #[test]
+    fn test_diesel_framework_safe_alternative_message() {
+        let stmt = parse_sql("REINDEX INDEX CONCURRENTLY idx_users_email;");
+        let violations = ReindexCheck.check(
+            &stmt,
+            &Config::default(),
+            &MigrationContext {
+                run_in_transaction: true,
+                no_transaction_hint: "Create `metadata.toml` in the migration directory with `run_in_transaction = false`.",
+            },
+        );
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0].safe_alternative.contains("metadata.toml"),
+            "Expected Diesel safe alternative message"
+        );
     }
 }

--- a/src/checks/rename_column.rs
+++ b/src/checks/rename_column.rs
@@ -13,13 +13,13 @@
 //! and finally remove the old column in a subsequent migration.
 
 use crate::checks::pg_helpers::{NodeEnum, ObjectType, range_var_name};
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 pub struct RenameColumnCheck;
 
 impl Check for RenameColumnCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let NodeEnum::RenameStmt(rename) = node else {
             return vec![];
         };

--- a/src/checks/rename_table.rs
+++ b/src/checks/rename_table.rs
@@ -11,13 +11,13 @@
 //! compatibility with running instances and avoids dangerous locks.
 
 use crate::checks::pg_helpers::{NodeEnum, ObjectType, range_var_name};
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 pub struct RenameTableCheck;
 
 impl Check for RenameTableCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let NodeEnum::RenameStmt(rename) = node else {
             return vec![];
         };

--- a/src/checks/short_int_primary_key.rs
+++ b/src/checks/short_int_primary_key.rs
@@ -17,7 +17,7 @@ use crate::checks::pg_helpers::{
     cmd_def_as_constraint, column_has_constraint, column_type_name, for_each_column_def,
     is_short_integer, range_var_name,
 };
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 const CONSTR_PRIMARY: i32 = ConstrType::ConstrPrimary as i32;
@@ -25,7 +25,7 @@ const CONSTR_PRIMARY: i32 = ConstrType::ConstrPrimary as i32;
 pub struct ShortIntegerPrimaryKeyCheck;
 
 impl Check for ShortIntegerPrimaryKeyCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let mut violations = vec![];
 
         // Inline PRIMARY KEY on column definitions

--- a/src/checks/test_utils.rs
+++ b/src/checks/test_utils.rs
@@ -10,7 +10,11 @@ macro_rules! assert_detects_violation {
     ($check:expr, $sql:expr, $operation:expr) => {{
         use $crate::checks::test_utils::parse_sql;
         let stmt = parse_sql($sql);
-        let violations = $check.check(&stmt, &$crate::config::Config::default());
+        let violations = $check.check(
+            &stmt,
+            &$crate::config::Config::default(),
+            &$crate::checks::MigrationContext::default(),
+        );
         assert_eq!(violations.len(), 1, "Expected exactly 1 violation");
         assert_eq!(
             violations[0].operation, $operation,
@@ -27,7 +31,7 @@ macro_rules! assert_detects_violation_with_config {
     ($check:expr, $sql:expr, $operation:expr, $config:expr) => {{
         use $crate::checks::test_utils::parse_sql;
         let stmt = parse_sql($sql);
-        let violations = $check.check(&stmt, $config);
+        let violations = $check.check(&stmt, $config, &$crate::checks::MigrationContext::default());
         assert_eq!(violations.len(), 1, "Expected exactly 1 violation");
         assert_eq!(
             violations[0].operation, $operation,
@@ -44,7 +48,7 @@ macro_rules! assert_allows_with_config {
     ($check:expr, $sql:expr, $config:expr) => {{
         use $crate::checks::test_utils::parse_sql;
         let stmt = parse_sql($sql);
-        let violations = $check.check(&stmt, $config);
+        let violations = $check.check(&stmt, $config, &$crate::checks::MigrationContext::default());
         assert_eq!(
             violations.len(),
             0,
@@ -61,7 +65,11 @@ macro_rules! assert_allows {
     ($check:expr, $sql:expr) => {{
         use $crate::checks::test_utils::parse_sql;
         let stmt = parse_sql($sql);
-        let violations = $check.check(&stmt, &$crate::config::Config::default());
+        let violations = $check.check(
+            &stmt,
+            &$crate::config::Config::default(),
+            &$crate::checks::MigrationContext::default(),
+        );
         assert_eq!(
             violations.len(),
             0,
@@ -79,7 +87,11 @@ macro_rules! assert_detects_violation_containing {
     ($check:expr, $sql:expr, $operation:expr, $($substring:expr),+) => {{
         use $crate::checks::test_utils::parse_sql;
         let stmt = parse_sql($sql);
-        let violations = $check.check(&stmt, &$crate::config::Config::default());
+        let violations = $check.check(
+            &stmt,
+            &$crate::config::Config::default(),
+            &$crate::checks::MigrationContext::default(),
+        );
         assert_eq!(violations.len(), 1, "Expected exactly 1 violation");
         assert_eq!(
             violations[0].operation, $operation,
@@ -104,7 +116,11 @@ macro_rules! assert_detects_n_violations_any_containing {
     ($check:expr, $sql:expr, $n:expr, $($substring:expr),+) => {{
         use $crate::checks::test_utils::parse_sql;
         let stmt = parse_sql($sql);
-        let violations = $check.check(&stmt, &$crate::config::Config::default());
+        let violations = $check.check(
+            &stmt,
+            &$crate::config::Config::default(),
+            &$crate::checks::MigrationContext::default(),
+        );
         assert_eq!(violations.len(), $n, "Expected exactly {} violations", $n);
         $(
             assert!(
@@ -123,7 +139,11 @@ macro_rules! assert_detects_n_violations {
     ($check:expr, $sql:expr, $n:expr, $operation:expr) => {{
         use $crate::checks::test_utils::parse_sql;
         let stmt = parse_sql($sql);
-        let violations = $check.check(&stmt, &$crate::config::Config::default());
+        let violations = $check.check(
+            &stmt,
+            &$crate::config::Config::default(),
+            &$crate::checks::MigrationContext::default(),
+        );
         assert_eq!(violations.len(), $n, "Expected exactly {} violations", $n);
         for v in &violations {
             assert_eq!(

--- a/src/checks/timestamp_type.rs
+++ b/src/checks/timestamp_type.rs
@@ -24,13 +24,13 @@ use crate::checks::pg_helpers::{
     NodeEnum, alter_table_cmds, cmd_def_as_column_def, column_type_name, for_each_column_def,
     is_timestamp_without_tz,
 };
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 pub struct TimestampTypeCheck;
 
 impl Check for TimestampTypeCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let is_create = matches!(node, NodeEnum::CreateStmt(_));
 
         // Handle CREATE TABLE via for_each_column_def

--- a/src/checks/truncate_table.rs
+++ b/src/checks/truncate_table.rs
@@ -11,13 +11,13 @@
 //! allowing concurrent access to the table.
 
 use crate::checks::pg_helpers::{NodeEnum, range_var_name};
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 pub struct TruncateTableCheck;
 
 impl Check for TruncateTableCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let NodeEnum::TruncateStmt(truncate) = node else {
             return vec![];
         };

--- a/src/checks/unnamed_constraint.rs
+++ b/src/checks/unnamed_constraint.rs
@@ -13,13 +13,13 @@ use crate::checks::pg_helpers::{
     ConstrType, NodeEnum, alter_table_cmds, cmd_def_as_constraint, constraint_columns_str,
     range_var_name,
 };
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 pub struct UnnamedConstraintCheck;
 
 impl Check for UnnamedConstraintCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let Some((table_name, cmds)) = alter_table_cmds(node) else {
             return vec![];
         };

--- a/src/checks/wide_index.rs
+++ b/src/checks/wide_index.rs
@@ -10,7 +10,7 @@
 //! query patterns instead.
 
 use crate::checks::pg_helpers::{NodeEnum, range_var_name};
-use crate::checks::{Check, Config};
+use crate::checks::{Check, Config, MigrationContext};
 use crate::violation::Violation;
 
 const MAX_COLUMNS: usize = 3;
@@ -18,7 +18,7 @@ const MAX_COLUMNS: usize = 3;
 pub struct WideIndexCheck;
 
 impl Check for WideIndexCheck {
-    fn check(&self, node: &NodeEnum, _config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, _config: &Config, _ctx: &MigrationContext) -> Vec<Violation> {
         let NodeEnum::IndexStmt(index_stmt) = node else {
             return vec![];
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub mod safety_checker;
 pub mod scripting;
 pub mod violation;
 
-pub use adapters::{MigrationAdapter, MigrationFile};
+pub use adapters::{MigrationAdapter, MigrationContext, MigrationFile};
 pub use config::{Config, ConfigError};
 pub use safety_checker::SafetyChecker;
 pub use violation::Violation;

--- a/src/safety_checker.rs
+++ b/src/safety_checker.rs
@@ -1,5 +1,5 @@
 use crate::adapters::{DieselAdapter, MigrationAdapter, SqlxAdapter};
-use crate::checks::Registry;
+use crate::checks::{MigrationContext, Registry};
 use crate::config::Config;
 use crate::error::Result;
 use crate::parser;
@@ -110,6 +110,7 @@ impl SafetyChecker {
             &parsed.sql,
             &parsed.ignore_ranges,
             &self.config,
+            &MigrationContext::default(),
         ))
     }
 
@@ -117,12 +118,18 @@ impl SafetyChecker {
     pub fn check_file(&self, path: &Utf8Path) -> Result<Vec<Violation>> {
         let sql = fs::read_to_string(path)?;
 
+        let ctx = self
+            .adapter()
+            .map(|a| a.extract_migration_metadata(path))
+            .unwrap_or_default();
+
         match parser::parse_with_metadata(&sql) {
             Ok(parsed) => Ok(self.registry.check_stmts_with_context(
                 &parsed.stmts,
                 &parsed.sql,
                 &parsed.ignore_ranges,
                 &self.config,
+                &ctx,
             )),
             Err(e) => Err(e.with_file_context(path.as_str(), sql)),
         }
@@ -145,6 +152,8 @@ impl SafetyChecker {
         for mig_file in migration_files {
             let sql = fs::read_to_string(&mig_file.path)?;
 
+            let ctx = adapter.extract_migration_metadata(&mig_file.path);
+
             match parser::parse_with_metadata(&sql) {
                 Ok(parsed) => {
                     let violations = self.registry.check_stmts_with_context(
@@ -152,6 +161,7 @@ impl SafetyChecker {
                         &parsed.sql,
                         &parsed.ignore_ranges,
                         &self.config,
+                        &ctx,
                     );
                     if !violations.is_empty() {
                         results.push((mig_file.path.to_string(), violations));
@@ -256,11 +266,17 @@ mod tests {
     }
 
     #[test]
-    fn test_reindex_concurrently_safe() {
+    fn test_reindex_concurrently_in_transaction_detected() {
+        // check_sql uses MigrationContext::default() (run_in_transaction=true),
+        // so REINDEX CONCURRENTLY is flagged as requiring no-transaction context.
         let checker = SafetyChecker::new();
         let sql = "REINDEX INDEX CONCURRENTLY idx_users_email;";
         let violations = checker.check_sql(sql).unwrap();
-        assert_eq!(violations.len(), 0);
+        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            violations[0].operation,
+            "REINDEX CONCURRENTLY inside a transaction"
+        );
     }
 
     #[test]
@@ -383,5 +399,138 @@ mod tests {
             .check_buffer(&mut BufReader::new(Cursor::new(input_data)))
             .unwrap();
         assert_eq!(violations.len(), 2)
+    }
+
+    // --- Integration tests: metadata-aware CONCURRENTLY detection ---
+
+    #[test]
+    fn test_diesel_concurrently_without_metadata_toml_is_violation() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let migration_dir = temp_dir.path().join("2024_01_01_000000_add_idx");
+        fs::create_dir(&migration_dir).unwrap();
+        fs::write(
+            migration_dir.join("up.sql"),
+            "CREATE INDEX CONCURRENTLY idx_users_email ON users(email);",
+        )
+        .unwrap();
+        // No metadata.toml — defaults to run_in_transaction=true
+
+        let config = Config {
+            framework: "diesel".to_string(),
+            ..Default::default()
+        };
+        let checker = SafetyChecker::with_config(config);
+        let dir_path =
+            camino::Utf8Path::from_path(temp_dir.path()).expect("path should be valid UTF-8");
+
+        let results = checker.check_directory(dir_path).unwrap();
+        let total_violations: usize = results.iter().map(|(_, v)| v.len()).sum();
+        assert_eq!(
+            total_violations, 1,
+            "Expected 1 violation (CONCURRENTLY in transaction)"
+        );
+        assert_eq!(
+            results[0].1[0].operation,
+            "CREATE INDEX CONCURRENTLY inside a transaction"
+        );
+    }
+
+    #[test]
+    fn test_diesel_concurrently_with_metadata_toml_is_safe() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let migration_dir = temp_dir.path().join("2024_01_01_000000_add_idx");
+        fs::create_dir(&migration_dir).unwrap();
+        fs::write(
+            migration_dir.join("up.sql"),
+            "CREATE INDEX CONCURRENTLY idx_users_email ON users(email);",
+        )
+        .unwrap();
+        fs::write(
+            migration_dir.join("metadata.toml"),
+            "run_in_transaction = false\n",
+        )
+        .unwrap();
+
+        let config = Config {
+            framework: "diesel".to_string(),
+            ..Default::default()
+        };
+        let checker = SafetyChecker::with_config(config);
+        let dir_path =
+            camino::Utf8Path::from_path(temp_dir.path()).expect("path should be valid UTF-8");
+
+        let results = checker.check_directory(dir_path).unwrap();
+        let total_violations: usize = results.iter().map(|(_, v)| v.len()).sum();
+        assert_eq!(
+            total_violations, 0,
+            "Expected no violations with metadata.toml"
+        );
+    }
+
+    #[test]
+    fn test_sqlx_concurrently_without_directive_is_violation() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("20240101000000_add_idx.up.sql"),
+            "CREATE INDEX CONCURRENTLY idx_users_email ON users(email);",
+        )
+        .unwrap();
+        // No -- no-transaction directive
+
+        let config = Config {
+            framework: "sqlx".to_string(),
+            ..Default::default()
+        };
+        let checker = SafetyChecker::with_config(config);
+        let dir_path =
+            camino::Utf8Path::from_path(temp_dir.path()).expect("path should be valid UTF-8");
+
+        let results = checker.check_directory(dir_path).unwrap();
+        let total_violations: usize = results.iter().map(|(_, v)| v.len()).sum();
+        assert_eq!(
+            total_violations, 1,
+            "Expected 1 violation (CONCURRENTLY inside a transaction)"
+        );
+        assert_eq!(
+            results[0].1[0].operation,
+            "CREATE INDEX CONCURRENTLY inside a transaction"
+        );
+    }
+
+    #[test]
+    fn test_sqlx_concurrently_with_directive_is_safe() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("20240101000000_add_idx.up.sql"),
+            "-- no-transaction\nCREATE INDEX CONCURRENTLY idx_users_email ON users(email);",
+        )
+        .unwrap();
+
+        let config = Config {
+            framework: "sqlx".to_string(),
+            ..Default::default()
+        };
+        let checker = SafetyChecker::with_config(config);
+        let dir_path =
+            camino::Utf8Path::from_path(temp_dir.path()).expect("path should be valid UTF-8");
+
+        let results = checker.check_directory(dir_path).unwrap();
+        let total_violations: usize = results.iter().map(|(_, v)| v.len()).sum();
+        assert_eq!(
+            total_violations, 0,
+            "Expected no violations with -- no-transaction"
+        );
     }
 }

--- a/src/scripting.rs
+++ b/src/scripting.rs
@@ -1,4 +1,4 @@
-use crate::checks::Check;
+use crate::checks::{Check, MigrationContext};
 use crate::config::Config;
 use crate::violation::Violation;
 use camino::Utf8Path;
@@ -32,7 +32,7 @@ impl Check for CustomCheck {
         self.name
     }
 
-    fn check(&self, node: &NodeEnum, config: &Config) -> Vec<Violation> {
+    fn check(&self, node: &NodeEnum, config: &Config, ctx: &MigrationContext) -> Vec<Violation> {
         // Serialize the pg_query node to a Rhai Dynamic value via serde
         let dynamic_node = match rhai::serde::to_dynamic(node) {
             Ok(d) => d,
@@ -56,9 +56,12 @@ impl Check for CustomCheck {
             }
         };
 
+        let dynamic_ctx = rhai::serde::to_dynamic(ctx).unwrap();
+
         let mut scope = rhai::Scope::new();
         scope.push("node", dynamic_node);
         scope.push("config", dynamic_config);
+        scope.push("ctx", dynamic_ctx);
 
         match self
             .engine
@@ -320,6 +323,21 @@ mod tests {
         sql: &str,
         config: &crate::config::Config,
     ) -> Vec<Violation> {
+        run_script_with_ctx(
+            script,
+            sql,
+            config,
+            &crate::checks::MigrationContext::default(),
+        )
+    }
+
+    /// Helper: run a script against a node with explicit config and ctx and return violations.
+    fn run_script_with_ctx(
+        script: &str,
+        sql: &str,
+        config: &crate::config::Config,
+        ctx: &crate::checks::MigrationContext,
+    ) -> Vec<Violation> {
         let engine = Arc::new(create_engine());
         let ast = engine.compile(script).expect("script should compile");
         let name: &'static str = Box::leak("test_check".to_string().into_boxed_str());
@@ -329,7 +347,7 @@ mod tests {
         let mut all_violations = Vec::new();
         for raw_stmt in &stmts {
             if let Some(node) = extract_node(raw_stmt) {
-                all_violations.extend(check.check(node, config));
+                all_violations.extend(check.check(node, config, ctx));
             }
         }
         all_violations
@@ -607,6 +625,60 @@ mod tests {
         assert_eq!(checks.len(), 0);
         assert_eq!(errors.len(), 1);
         assert!(errors[0].message.contains("Failed to read directory"));
+    }
+
+    #[test]
+    fn test_ctx_run_in_transaction_false_no_violation() {
+        // CONCURRENTLY outside a transaction — no violation
+        let ctx = crate::checks::MigrationContext {
+            run_in_transaction: false,
+            no_transaction_hint: "",
+        };
+        let violations = run_script_with_ctx(
+            r#"
+            let stmt = node.IndexStmt;
+            if stmt == () { return; }
+            if stmt.concurrent && ctx.run_in_transaction {
+                #{ operation: "CONCURRENTLY in transaction", problem: "will fail", safe_alternative: ctx.no_transaction_hint }
+            }
+            "#,
+            "CREATE INDEX CONCURRENTLY idx ON users(email);",
+            &crate::config::Config::default(),
+            &ctx,
+        );
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_ctx_run_in_transaction_true_produces_violation() {
+        // CONCURRENTLY inside a transaction — should flag it
+        let ctx = crate::checks::MigrationContext {
+            run_in_transaction: true,
+            no_transaction_hint: "Add -- diesel:no-transaction to the migration file.",
+        };
+        let violations = run_script_with_ctx(
+            r#"
+            let stmt = node.IndexStmt;
+            if stmt == () { return; }
+            if stmt.concurrent && ctx.run_in_transaction {
+                #{
+                    operation: "CONCURRENTLY in transaction",
+                    problem: "will fail",
+                    safe_alternative: ctx.no_transaction_hint
+                }
+            }
+            "#,
+            "CREATE INDEX CONCURRENTLY idx ON users(email);",
+            &crate::config::Config::default(),
+            &ctx,
+        );
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].operation, "CONCURRENTLY in transaction");
+        assert!(
+            violations[0]
+                .safe_alternative
+                .contains("diesel:no-transaction")
+        );
     }
 
     #[test]

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -577,8 +577,9 @@ disable_checks = ["DropColumnCheck"]
 
 #[test]
 fn test_diesel_concurrently_without_metadata_warns() {
-    // CONCURRENTLY used without metadata.toml should still collect the file
-    // (warning is printed to stderr, verified by the file being in results)
+    // CONCURRENTLY used without metadata.toml is now a violation:
+    // the migration defaults to run_in_transaction=true, so CONCURRENTLY will
+    // fail at runtime because PostgreSQL doesn't allow it inside a transaction.
     let temp_dir = TempDir::new().unwrap();
     let migration_dir = temp_dir.path().join("2024_01_01_000000_add_index");
     fs::create_dir(&migration_dir).unwrap();
@@ -596,9 +597,13 @@ fn test_diesel_concurrently_without_metadata_warns() {
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
 
-    // The file should still be collected and checked (no violations from the SQL itself
-    // since CREATE INDEX CONCURRENTLY is safe)
-    assert_eq!(results.len(), 0);
+    // The file should have 1 violation: CONCURRENTLY inside a transaction
+    assert_eq!(results.len(), 1, "Expected 1 file with violations");
+    assert_eq!(results[0].1.len(), 1, "Expected 1 violation");
+    assert_eq!(
+        results[0].1[0].operation,
+        "CREATE INDEX CONCURRENTLY inside a transaction"
+    );
 }
 
 #[test]

--- a/tests/fixtures/add_index_safe/metadata.toml
+++ b/tests/fixtures/add_index_safe/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/tests/fixtures/add_primary_key_safe/metadata.toml
+++ b/tests/fixtures/add_primary_key_safe/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/tests/fixtures/add_unique_constraint_safe/metadata.toml
+++ b/tests/fixtures/add_unique_constraint_safe/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/tests/fixtures/drop_index_safe/metadata.toml
+++ b/tests/fixtures/drop_index_safe/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/tests/fixtures/reindex_safe/metadata.toml
+++ b/tests/fixtures/reindex_safe/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/tests/fixtures/wide_index_safe/metadata.toml
+++ b/tests/fixtures/wide_index_safe/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/tests/fixtures/wide_index_unsafe/metadata.toml
+++ b/tests/fixtures/wide_index_unsafe/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -517,10 +517,19 @@ fn test_sqlx_suffix_format_detected() {
 
 #[test]
 fn test_safe_sqlx_fixtures_pass() {
-    let checker = SafetyChecker::new();
+    use diesel_guard::Config;
 
+    // Use the SQLx adapter so that the `-- no-transaction` directive is recognized.
+    let config = Config {
+        framework: "sqlx".to_string(),
+        ..Default::default()
+    };
+    let checker = SafetyChecker::with_config(config);
+
+    // Note: sqlx_concurrently_missing_directive is intentionally excluded here —
+    // it contains CREATE INDEX CONCURRENTLY without a no-transaction directive,
+    // which is now correctly detected as a violation.
     let safe_sqlx_fixtures = vec![
-        "tests/fixtures_sqlx/sqlx_concurrently_missing_directive",
         "tests/fixtures_sqlx/sqlx_concurrently_with_directive",
         "tests/fixtures_sqlx/sqlx_reindex_safe",
     ];
@@ -537,6 +546,30 @@ fn test_safe_sqlx_fixtures_pass() {
             fixture, total_violations
         );
     }
+}
+
+#[test]
+fn test_sqlx_concurrently_without_no_transaction_detected() {
+    use diesel_guard::Config;
+
+    let config = Config {
+        framework: "sqlx".to_string(),
+        ..Default::default()
+    };
+    let checker = SafetyChecker::with_config(config);
+
+    let results = checker
+        .check_directory(Utf8Path::new(
+            "tests/fixtures_sqlx/sqlx_concurrently_missing_directive",
+        ))
+        .unwrap();
+
+    assert_eq!(results.len(), 1, "Expected 1 file with violations");
+    assert_eq!(results[0].1.len(), 1, "Expected 1 violation");
+    assert_eq!(
+        results[0].1[0].operation,
+        "CREATE INDEX CONCURRENTLY inside a transaction"
+    );
 }
 
 #[test]
@@ -574,16 +607,17 @@ fn test_check_all_sqlx_fixtures() {
 
     // Expected violations (with check_down = false):
     // 1. sqlx_suffix_add_column_unsafe/.up.sql - 1 violation (ADD COLUMN with DEFAULT)
-    // 2. sqlx_reindex_unsafe - 1 violation (REINDEX without CONCURRENTLY)
-    // Note: .down.sql correctly skipped, CONCURRENTLY and safe fixtures have 0 violations
+    // 2. sqlx_concurrently_missing_directive - 1 violation (CREATE INDEX CONCURRENTLY inside a transaction)
+    // 3. sqlx_reindex_unsafe - 1 violation (REINDEX without CONCURRENTLY)
+    // Note: .down.sql correctly skipped, with-directive and safe fixtures have 0 violations
     assert_eq!(
-        files_with_violations, 2,
-        "Expected 2 files with violations, got {}",
+        files_with_violations, 3,
+        "Expected 3 files with violations, got {}",
         files_with_violations
     );
     assert_eq!(
-        all_violations, 2,
-        "Expected 2 total violations, got {}",
+        all_violations, 3,
+        "Expected 3 total violations, got {}",
         all_violations
     );
 }

--- a/tests/safety_assured_test.rs
+++ b/tests/safety_assured_test.rs
@@ -224,8 +224,8 @@ ALTER TABLE users ADD COLUMN email VARCHAR(255);
 ALTER TABLE users DROP COLUMN deprecated_field;
 -- safety-assured:end
 
--- Another safe operation
-CREATE INDEX CONCURRENTLY users_email_idx ON users(email);
+-- Another safe operation (no default, no lock)
+ALTER TABLE users ADD COLUMN name VARCHAR(255);
     "#;
 
     let violations = checker.check_sql(sql).unwrap();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Checks now respect per-migration context (metadata.toml and in-file no-transaction directives): concurrent operations are allowed or flagged accordingly, with actionable, framework-specific guidance.

* **Documentation**
  * Docs and examples updated to introduce the ctx variable, show how to construct/use MigrationContext in tests and custom checks, and detail when context is exposed to scripts.

* **Tests**
  * Tests and fixtures expanded to cover metadata-driven transactional behavior across frameworks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->