### PR TITLE
Use "./migrations" as the default path for check

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ powershell -ExecutionPolicy Bypass -c "irm https://github.com/ayarotsky/diesel-g
 ## Quick Start
 
 ```sh
-diesel-guard init          # creates diesel-guard.toml
-diesel-guard check migrations/
+diesel-guard init   # creates diesel-guard.toml
+diesel-guard check  # checks ./migrations/ by default
 ```
 
 When it finds an unsafe migration:
@@ -132,6 +132,12 @@ ALTER TABLE users DROP COLUMN legacy_field;
 ## Further Reading
 
 - [Your Diesel Migrations Might Be Ticking Time Bombs](https://dev.to/ayarotsky/your-diesel-migrations-might-be-ticking-time-bombs-30g7)
+- [Zero-downtime Postgres migrations: the hard parts](https://gocardless.com/blog/zero-downtime-postgres-migrations-the-hard-parts/)
+- [Zero-downtime Postgres migrations: a little help](https://gocardless.com/blog/zero-downtime-postgres-migrations-a-little-help/)
+- [Seven tips for dealing with Postgres locks](https://www.citusdata.com/blog/2018/02/22/seven-tips-for-dealing-with-postgres-locks/)
+- [Move fast and migrate things: how we automated migrations in Postgres](https://benchling.engineering/move-fast-and-migrate-things-how-we-automated-migrations-in-postgres-d60aba0fc3d4)
+- [PostgreSQL at scale: database schema changes without downtime](https://medium.com/paypal-tech/postgresql-at-scale-database-schema-changes-without-downtime-20d3749ed680)
+- [SQL Style Guide](https://www.sqlstyle.guide/)
 
 ## Credits
 

--- a/docs/src/ci-cd.md
+++ b/docs/src/ci-cd.md
@@ -67,5 +67,5 @@ jobs:
         run: cargo install diesel-guard
 
       - name: Check DB migrations
-        run: diesel-guard check migrations/
+        run: diesel-guard check
 ```

--- a/docs/src/custom-checks.md
+++ b/docs/src/custom-checks.md
@@ -48,7 +48,7 @@ custom_checks_dir = "checks"
 4. Run as usual:
 
 ```sh
-diesel-guard check migrations/
+diesel-guard check
 ```
 
 ## How It Works

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -9,7 +9,8 @@ diesel-guard check migrations/2024_01_01_create_users/up.sql
 ## Check All Migrations in a Directory
 
 ```sh
-diesel-guard check migrations/
+diesel-guard check              # defaults to ./migrations/
+diesel-guard check migrations/  # or specify an explicit path
 ```
 
 ## Pipe SQL Directly

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ that acquire dangerous locks or cause table rewrites.
 
 QUICK START:
   diesel-guard init              Create diesel-guard.toml in the current directory
-  diesel-guard check migrations/ Check all migration files in a directory
+  diesel-guard check             Check all migrations in ./migrations/
   diesel-guard check up.sql      Check a single file
   diesel-guard check -           Read SQL from stdin
 
@@ -44,6 +44,8 @@ PATH can be:
   - A single .sql file
   - \"-\" to read from stdin
 
+If PATH is omitted, defaults to \"migrations/\".
+
 diesel-guard looks for diesel-guard.toml in the current directory. If no config
 file is found, default settings are used with a warning.
 
@@ -52,13 +54,14 @@ Exit codes:
   1  One or more violations found
 
 EXAMPLES:
+  diesel-guard check
   diesel-guard check migrations/
   diesel-guard check db/migrate/20240101_add_users/up.sql
   cat migration.sql | diesel-guard check -
   diesel-guard check migrations/ --format json")]
     Check {
-        /// Path to migration file or directory, or "-" for stdin
-        path: Utf8PathBuf,
+        /// Path to migration file or directory, or "-" for stdin (default: "migrations/")
+        path: Option<Utf8PathBuf>,
 
         /// Output format: "text" (default) or "json"
         #[arg(long, default_value = "text")]
@@ -119,6 +122,7 @@ fn main() -> Result<()> {
 
     match cli.command {
         Commands::Check { path, format } => {
+            let path = path.unwrap_or_else(|| Utf8PathBuf::from("migrations"));
             // Load configuration with explicit error handling
             let config = match Config::load() {
                 Ok(config) => config,
@@ -207,7 +211,7 @@ fn main() -> Result<()> {
                 "1. Edit diesel-guard.toml and set the 'framework' field to \"diesel\" or \"sqlx\""
             );
             println!("2. Customize other configuration options as needed");
-            println!("3. Run 'diesel-guard check <path>' to check your migrations");
+            println!("3. Run 'diesel-guard check' to check your migrations");
         }
     }
 

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -1,4 +1,5 @@
 use std::{
+    fs,
     io::Write,
     path::PathBuf,
     process::{Command, Stdio},
@@ -19,6 +20,33 @@ fn diesel_guard_bin() -> PathBuf {
     path.push("debug");
     path.push("diesel-guard");
     path
+}
+
+#[test]
+fn test_default_migrations_dir() {
+    let bin = diesel_guard_bin();
+    let tempdir = tempfile::tempdir().expect("Failed to create tempdir");
+    let migrations_dir = tempdir.path().join("migrations");
+    fs::create_dir(&migrations_dir).expect("Failed to create migrations dir");
+    fs::write(
+        migrations_dir.join("up.sql"),
+        "ALTER TABLE users ADD COLUMN foo TEXT;",
+    )
+    .expect("Failed to write migration");
+
+    let output = Command::new(&bin)
+        .arg("check")
+        .current_dir(tempdir.path())
+        .output()
+        .expect("Failed to execute check command");
+
+    assert!(
+        output.status.success(),
+        "Check command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("✅ No unsafe migrations detected!\n"));
 }
 
 #[test]

--- a/tests/init_test.rs
+++ b/tests/init_test.rs
@@ -49,7 +49,7 @@ fn test_init_creates_config() {
         "✓ Created diesel-guard.toml\n\nNext steps:\n\
          1. Edit diesel-guard.toml and set the 'framework' field to \"diesel\" or \"sqlx\"\n\
          2. Customize other configuration options as needed\n\
-         3. Run 'diesel-guard check <path>' to check your migrations\n"
+         3. Run 'diesel-guard check' to check your migrations\n"
     );
 }
 
@@ -144,7 +144,7 @@ fn test_init_force_overwrites_existing() {
         "✓ Overwrote diesel-guard.toml\n\nNext steps:\n\
          1. Edit diesel-guard.toml and set the 'framework' field to \"diesel\" or \"sqlx\"\n\
          2. Customize other configuration options as needed\n\
-         3. Run 'diesel-guard check <path>' to check your migrations\n"
+         3. Run 'diesel-guard check' to check your migrations\n"
     );
 
     // Verify file was overwritten with template


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * The check command now defaults to the project's ./migrations/ directory when run without a path, simplifying usage while still allowing explicit paths.

* **Documentation**
  * Updated examples and guidance across docs to reflect the new default and show both implicit and explicit invocation.

* **Tests**
  * Added/updated tests to cover the default migrations-directory behavior and related init messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->