### PR TITLE
feat: add migration-scoped check disables

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ ALTER TABLE users DROP COLUMN legacy_field;
 -- safety-assured:end
 ```
 
+To suppress only one known-safe check while keeping other checks active for the same migration, disable that check by name:
+
+```sql
+-- diesel-guard:disable AddColumnCheck
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+```
+
 ## Further Reading
 
 - [Your Diesel Migrations Might Be Ticking Time Bombs](https://dev.to/ayarotsky/your-diesel-migrations-might-be-ticking-time-bombs-30g7)

--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ To suppress only one known-safe check while keeping other checks active for the 
 ```sql
 -- diesel-guard:disable AddColumnCheck
 ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+
+-- Disable multiple checks with a comma-separated list:
+-- diesel-guard:disable AddColumnCheck, IdempotencyAlterCheck
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
 ```
 
 ## Further Reading

--- a/diesel-guard.toml.example
+++ b/diesel-guard.toml.example
@@ -38,6 +38,10 @@ framework = "diesel"
 #
 # Default: [] (all checks enabled)
 # disable_checks = []
+#
+# To disable a check for one migration only:
+#   Any framework: add `-- diesel-guard:disable AddColumnCheck` to the migration SQL.
+#   Diesel only: add `disable_checks = ["AddColumnCheck"]` to that migration's metadata.toml.
 
 # Enable only specific safety checks (whitelist)
 # When set, only the listed checks run — all others are skipped.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -35,6 +35,10 @@ check_down = true
 # Disable specific checks (blacklist)
 disable_checks = ["AddColumnCheck"]
 
+# Disable specific checks for one migration:
+#   Any framework: add `-- diesel-guard:disable AddColumnCheck` to the migration SQL.
+#   Diesel only: add `disable_checks = ["AddColumnCheck"]` to that migration's metadata.toml.
+
 # Run only specific checks (whitelist). Cannot be used with disable_checks.
 enable_checks = ["AddIndexCheck", "AddNotNullCheck"]
 

--- a/docs/src/safety-assured.md
+++ b/docs/src/safety-assured.md
@@ -11,6 +11,30 @@ ALTER TABLE posts DROP COLUMN old_field;
 
 All statements between the start and end markers are skipped by all checks — both built-in and custom.
 
+## Disable Specific Checks for One Migration
+
+When only one check is known to be acceptable for a migration, disable that check by name instead of suppressing the whole statement:
+
+```sql
+-- diesel-guard:disable AddColumnCheck
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+```
+
+Other checks still run on the same migration. For example, the statement above can still be flagged by `IdempotencyAlterCheck` if it is missing `IF NOT EXISTS`.
+
+Disable multiple checks with a comma-separated list:
+
+```sql
+-- diesel-guard:disable AddColumnCheck, IdempotencyAlterCheck
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+```
+
+For Diesel directory migrations, you can also put migration-scoped disables in that migration's `metadata.toml`:
+
+```toml
+disable_checks = ["AddColumnCheck"]
+```
+
 ## Multiple Blocks
 
 ```sql

--- a/src/adapters/diesel.rs
+++ b/src/adapters/diesel.rs
@@ -34,6 +34,8 @@ pub struct DieselAdapter;
 #[derive(Deserialize, Default)]
 struct MetadataFile {
     run_in_transaction: Option<bool>,
+    #[serde(default)]
+    disable_checks: Vec<String>,
 }
 
 impl MigrationAdapter for DieselAdapter {
@@ -104,6 +106,7 @@ impl MigrationAdapter for DieselAdapter {
             return MigrationContext {
                 run_in_transaction: true,
                 no_transaction_hint: NO_TRANSACTION_HINT,
+                ..MigrationContext::default()
             };
         };
         let metadata_path = parent.join("metadata.toml");
@@ -112,6 +115,7 @@ impl MigrationAdapter for DieselAdapter {
             return MigrationContext {
                 run_in_transaction: true,
                 no_transaction_hint: NO_TRANSACTION_HINT,
+                ..MigrationContext::default()
             };
         };
 
@@ -120,6 +124,7 @@ impl MigrationAdapter for DieselAdapter {
         MigrationContext {
             run_in_transaction: parsed.run_in_transaction.unwrap_or(true),
             no_transaction_hint: NO_TRANSACTION_HINT,
+            disabled_checks: parsed.disable_checks,
         }
     }
 }

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -28,6 +28,8 @@ pub struct MigrationContext {
     /// Framework-specific hint for how to opt out of transactions.
     /// Empty string when no framework context is available (e.g. `check_sql`).
     pub no_transaction_hint: &'static str,
+    /// Check names disabled for this specific migration.
+    pub disabled_checks: Vec<String>,
 }
 
 impl Default for MigrationContext {
@@ -35,7 +37,23 @@ impl Default for MigrationContext {
         Self {
             run_in_transaction: true,
             no_transaction_hint: "",
+            disabled_checks: Vec::new(),
         }
+    }
+}
+
+impl MigrationContext {
+    /// Return a copy of this context with additional check names disabled.
+    #[must_use]
+    pub fn with_disabled_checks(&self, disabled_checks: &[String]) -> Self {
+        let mut ctx = self.clone();
+        ctx.disabled_checks.extend(disabled_checks.iter().cloned());
+        ctx
+    }
+
+    /// Return true when this migration disables a specific check.
+    pub fn disables_check(&self, check_name: &str) -> bool {
+        self.disabled_checks.iter().any(|name| name == check_name)
     }
 }
 

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -46,9 +46,22 @@ impl MigrationContext {
     /// Return a copy of this context with additional check names disabled.
     #[must_use]
     pub fn with_disabled_checks(&self, disabled_checks: &[String]) -> Self {
-        let mut ctx = self.clone();
-        ctx.disabled_checks.extend(disabled_checks.iter().cloned());
+        let mut ctx = Self {
+            disabled_checks: Vec::new(),
+            ..self.clone()
+        };
+
+        for check_name in self.disabled_checks.iter().chain(disabled_checks) {
+            ctx.push_disabled_check_once(check_name);
+        }
+
         ctx
+    }
+
+    fn push_disabled_check_once(&mut self, check_name: &str) {
+        if !self.disabled_checks.iter().any(|name| name == check_name) {
+            self.disabled_checks.push(check_name.to_string());
+        }
     }
 
     /// Return true when this migration disables a specific check.
@@ -196,5 +209,28 @@ mod tests {
             Some("20240101000000"),
             "create_users"
         ));
+    }
+
+    #[test]
+    fn test_with_disabled_checks_deduplicates_names() {
+        let ctx = MigrationContext {
+            disabled_checks: vec![
+                "AddColumnCheck".to_string(),
+                "IdempotencyAlterCheck".to_string(),
+            ],
+            ..MigrationContext::default()
+        };
+
+        let ctx = ctx
+            .with_disabled_checks(&["AddColumnCheck".to_string(), "DropColumnCheck".to_string()]);
+
+        assert_eq!(
+            ctx.disabled_checks,
+            vec![
+                "AddColumnCheck".to_string(),
+                "IdempotencyAlterCheck".to_string(),
+                "DropColumnCheck".to_string(),
+            ]
+        );
     }
 }

--- a/src/adapters/sqlx.rs
+++ b/src/adapters/sqlx.rs
@@ -72,6 +72,7 @@ impl MigrationAdapter for SqlxAdapter {
             return MigrationContext {
                 run_in_transaction: true,
                 no_transaction_hint: NO_TRANSACTION_HINT,
+                ..MigrationContext::default()
             };
         };
 
@@ -83,6 +84,7 @@ impl MigrationAdapter for SqlxAdapter {
         MigrationContext {
             run_in_transaction: !has_no_transaction,
             no_transaction_hint: NO_TRANSACTION_HINT,
+            ..MigrationContext::default()
         }
     }
 }

--- a/src/checks/add_index.rs
+++ b/src/checks/add_index.rs
@@ -170,6 +170,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: true,
                 no_transaction_hint: "Create `metadata.toml` with `run_in_transaction = false`.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);
@@ -196,6 +197,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: false,
                 no_transaction_hint: "Create `metadata.toml` with `run_in_transaction = false`.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);
@@ -216,6 +218,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: true,
                 no_transaction_hint: "Add `-- no-transaction` as the first line of the migration file.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);
@@ -234,6 +237,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: true,
                 no_transaction_hint: "Create `metadata.toml` in the migration directory with `run_in_transaction = false`.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);

--- a/src/checks/drop_index.rs
+++ b/src/checks/drop_index.rs
@@ -194,6 +194,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: true,
                 no_transaction_hint: "Create `metadata.toml` with `run_in_transaction = false`.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);
@@ -220,6 +221,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: false,
                 no_transaction_hint: "Create `metadata.toml` with `run_in_transaction = false`.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);
@@ -253,6 +255,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: true,
                 no_transaction_hint: "Add `-- no-transaction` as the first line of the migration file.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);
@@ -271,6 +274,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: true,
                 no_transaction_hint: "Create `metadata.toml` in the migration directory with `run_in_transaction = false`.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);

--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -216,6 +216,7 @@ impl Registry {
         use crate::violation::Severity;
         self.checks
             .iter()
+            .filter(|check| !ctx.disables_check(check.name()))
             .flat_map(|check| {
                 let severity = if config.is_check_warning(check.name()) {
                     Severity::Warning

--- a/src/checks/refresh_matview.rs
+++ b/src/checks/refresh_matview.rs
@@ -155,6 +155,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: true,
                 no_transaction_hint: "Create `metadata.toml` with `run_in_transaction = false`.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);
@@ -181,6 +182,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: false,
                 no_transaction_hint: "Create `metadata.toml` with `run_in_transaction = false`.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);
@@ -201,6 +203,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: true,
                 no_transaction_hint: "Add `-- no-transaction` as the first line of the migration file.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);
@@ -219,6 +222,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: true,
                 no_transaction_hint: "Create `metadata.toml` in the migration directory with `run_in_transaction = false`.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);

--- a/src/checks/reindex.rs
+++ b/src/checks/reindex.rs
@@ -235,6 +235,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: true,
                 no_transaction_hint: "Create `metadata.toml` with `run_in_transaction = false`.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);
@@ -261,6 +262,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: false,
                 no_transaction_hint: "Create `metadata.toml` with `run_in_transaction = false`.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);
@@ -296,6 +298,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: true,
                 no_transaction_hint: "Add `-- no-transaction` as the first line of the migration file.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);
@@ -314,6 +317,7 @@ mod tests {
             &MigrationContext {
                 run_in_transaction: true,
                 no_transaction_hint: "Create `metadata.toml` in the migration directory with `run_in_transaction = false`.",
+                ..MigrationContext::default()
             },
         );
         assert_eq!(violations.len(), 1);

--- a/src/parser/comment_parser.rs
+++ b/src/parser/comment_parser.rs
@@ -103,7 +103,7 @@ impl CommentParser {
     }
 
     fn parse_disabled_checks_line(line: &str) -> Option<Vec<String>> {
-        let captures = DISABLE_CHECKS_DIRECTIVE.captures(line.trim())?;
+        let captures = DISABLE_CHECKS_DIRECTIVE.captures(line)?;
         let checks = captures
             .get(1)?
             .as_str()

--- a/src/parser/comment_parser.rs
+++ b/src/parser/comment_parser.rs
@@ -17,6 +17,12 @@ static START_DIRECTIVE: LazyLock<Regex> =
 static END_DIRECTIVE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)^\s*--\s*safety-assured:end\s*$").unwrap());
 
+/// Regex pattern for matching whole-migration check disable directives.
+/// Matches: -- diesel-guard:disable AddColumnCheck, DropColumnCheck
+/// Case-insensitive for the directive prefix; check names retain their original case.
+static DISABLE_CHECKS_DIRECTIVE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*--\s*diesel-guard:disable\s+(.+?)\s*$").unwrap());
+
 /// Represents a range of lines that should be ignored
 #[derive(Debug, Clone, PartialEq, Display)]
 #[display("lines {}-{}", start_line, end_line)]
@@ -75,6 +81,17 @@ impl CommentParser {
         Ok(ranges)
     }
 
+    /// Parse whole-migration check disable directives.
+    ///
+    /// Directives are comma-separated and apply to the entire SQL string:
+    /// `-- diesel-guard:disable AddColumnCheck, DropColumnCheck`
+    pub fn parse_disabled_checks(sql: &str) -> Vec<String> {
+        sql.lines()
+            .filter_map(Self::parse_disabled_checks_line)
+            .flatten()
+            .collect()
+    }
+
     /// Check if line is a start directive
     fn is_start_directive(line: &str) -> bool {
         START_DIRECTIVE.is_match(line)
@@ -83,6 +100,24 @@ impl CommentParser {
     /// Check if line is an end directive
     fn is_end_directive(line: &str) -> bool {
         END_DIRECTIVE.is_match(line)
+    }
+
+    fn parse_disabled_checks_line(line: &str) -> Option<Vec<String>> {
+        let captures = DISABLE_CHECKS_DIRECTIVE.captures(line.trim())?;
+        let checks = captures
+            .get(1)?
+            .as_str()
+            .split(',')
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+
+        if checks.is_empty() {
+            None
+        } else {
+            Some(checks)
+        }
     }
 }
 
@@ -223,6 +258,43 @@ ALTER TABLE posts ADD COLUMN body TEXT;
 
         let ranges = CommentParser::parse_ignore_ranges(sql).unwrap();
         assert_eq!(ranges.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_disabled_checks_directive() {
+        let sql = r"
+-- diesel-guard:disable AddColumnCheck, DropColumnCheck
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+        ";
+
+        let disabled = CommentParser::parse_disabled_checks(sql);
+        assert_eq!(disabled, vec!["AddColumnCheck", "DropColumnCheck"]);
+    }
+
+    #[test]
+    fn test_parse_disabled_checks_directive_is_case_insensitive() {
+        let sql = r"
+-- DIESEL-GUARD:DISABLE AddColumnCheck
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+        ";
+
+        let disabled = CommentParser::parse_disabled_checks(sql);
+        assert_eq!(disabled, vec!["AddColumnCheck"]);
+    }
+
+    #[test]
+    fn test_parse_multiple_disabled_checks_directives() {
+        let sql = r"
+-- diesel-guard:disable AddColumnCheck
+-- diesel-guard:disable DropColumnCheck, ReindexCheck
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+        ";
+
+        let disabled = CommentParser::parse_disabled_checks(sql);
+        assert_eq!(
+            disabled,
+            vec!["AddColumnCheck", "DropColumnCheck", "ReindexCheck"]
+        );
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11,6 +11,7 @@ pub struct ParsedSql {
     pub stmts: Vec<RawStmt>,
     pub sql: String,
     pub ignore_ranges: Vec<IgnoreRange>,
+    pub disabled_checks: Vec<String>,
 }
 
 /// Parse SQL string into AST statements
@@ -45,12 +46,14 @@ pub fn parse(sql: &str) -> Result<Vec<RawStmt>> {
 /// Parse SQL with metadata for safety-assured blocks
 pub fn parse_with_metadata(sql: &str) -> Result<ParsedSql> {
     let ignore_ranges = comment_parser::CommentParser::parse_ignore_ranges(sql)?;
+    let disabled_checks = comment_parser::CommentParser::parse_disabled_checks(sql);
     let stmts = parse(sql)?;
 
     Ok(ParsedSql {
         stmts,
         sql: sql.to_string(),
         ignore_ranges,
+        disabled_checks,
     })
 }
 
@@ -87,6 +90,7 @@ ALTER TABLE users DROP COLUMN email;
         let result = parse_with_metadata(sql).unwrap();
         assert_eq!(result.stmts.len(), 1);
         assert_eq!(result.ignore_ranges.len(), 1);
+        assert_eq!(result.disabled_checks.len(), 0);
         assert!(!result.sql.is_empty());
     }
 
@@ -97,7 +101,20 @@ ALTER TABLE users DROP COLUMN email;
         let result = parse_with_metadata(sql).unwrap();
         assert_eq!(result.stmts.len(), 1);
         assert_eq!(result.ignore_ranges.len(), 0);
+        assert_eq!(result.disabled_checks.len(), 0);
         assert_eq!(result.sql, sql);
+    }
+
+    #[test]
+    fn test_parse_with_metadata_disabled_checks() {
+        let sql = r"
+-- diesel-guard:disable AddColumnCheck
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+        ";
+
+        let result = parse_with_metadata(sql).unwrap();
+        assert_eq!(result.stmts.len(), 1);
+        assert_eq!(result.disabled_checks, vec!["AddColumnCheck"]);
     }
 
     #[test]

--- a/src/safety_checker.rs
+++ b/src/safety_checker.rs
@@ -12,6 +12,7 @@ use std::io::{self, BufRead, BufReader};
 pub struct SafetyChecker {
     registry: Registry,
     config: Config,
+    known_check_names: Vec<String>,
 }
 
 impl SafetyChecker {
@@ -71,12 +72,15 @@ impl SafetyChecker {
                 }
             })
             .collect();
+        let known_check_names = builtin_names
+            .iter()
+            .map(|name| (*name).to_string())
+            .chain(custom_names.iter().cloned())
+            .collect::<Vec<_>>();
 
         let warn_unknown = |names: &[String], field: &str| {
             for name in names {
-                if !builtin_names.contains(&name.as_str())
-                    && !custom_names.iter().any(|c| c == name)
-                {
+                if !known_check_names.iter().any(|known| known == name) {
                     eprintln!(
                         "Warning: Unknown check name '{name}' in {field}. Run --list-checks to see available checks."
                     );
@@ -88,7 +92,11 @@ impl SafetyChecker {
         warn_unknown(&config.enable_checks, "enable_checks");
         warn_unknown(&config.warn_checks, "warn_checks");
 
-        Self { registry, config }
+        Self {
+            registry,
+            config,
+            known_check_names,
+        }
     }
 
     /// Build the migration adapter for the configured framework.
@@ -103,15 +111,30 @@ impl SafetyChecker {
         }
     }
 
+    fn warn_unknown_migration_disabled_checks(&self, disabled_checks: &[String], source: &str) {
+        for name in disabled_checks {
+            if !self.known_check_names.iter().any(|known| known == name) {
+                eprintln!(
+                    "Warning: Unknown check name '{name}' in {source}. Run --list-checks to see available checks."
+                );
+            }
+        }
+    }
+
     /// Check SQL string for violations
     pub fn check_sql(&self, sql: &str) -> Result<ViolationList> {
         let parsed = parser::parse_with_metadata(sql)?;
+        let ctx = MigrationContext::default().with_disabled_checks(&parsed.disabled_checks);
+        self.warn_unknown_migration_disabled_checks(
+            &ctx.disabled_checks,
+            "migration-scoped disable_checks",
+        );
         Ok(self.registry.check_stmts_with_context(
             &parsed.stmts,
             &parsed.sql,
             &parsed.ignore_ranges,
             &self.config,
-            &MigrationContext::default(),
+            &ctx,
         ))
     }
 
@@ -125,13 +148,20 @@ impl SafetyChecker {
             .unwrap_or_default();
 
         match parser::parse_with_metadata(&sql) {
-            Ok(parsed) => Ok(self.registry.check_stmts_with_context(
-                &parsed.stmts,
-                &parsed.sql,
-                &parsed.ignore_ranges,
-                &self.config,
-                &ctx,
-            )),
+            Ok(parsed) => {
+                let ctx = ctx.with_disabled_checks(&parsed.disabled_checks);
+                self.warn_unknown_migration_disabled_checks(
+                    &ctx.disabled_checks,
+                    &format!("{path} migration-scoped disable_checks"),
+                );
+                Ok(self.registry.check_stmts_with_context(
+                    &parsed.stmts,
+                    &parsed.sql,
+                    &parsed.ignore_ranges,
+                    &self.config,
+                    &ctx,
+                ))
+            }
             Err(e) => Err(e.with_file_context(path.as_str(), sql)),
         }
     }
@@ -157,6 +187,11 @@ impl SafetyChecker {
 
             match parser::parse_with_metadata(&sql) {
                 Ok(parsed) => {
+                    let ctx = ctx.with_disabled_checks(&parsed.disabled_checks);
+                    self.warn_unknown_migration_disabled_checks(
+                        &ctx.disabled_checks,
+                        &format!("{} migration-scoped disable_checks", mig_file.path),
+                    );
                     let violations = self.registry.check_stmts_with_context(
                         &parsed.stmts,
                         &parsed.sql,

--- a/src/safety_checker.rs
+++ b/src/safety_checker.rs
@@ -112,8 +112,20 @@ impl SafetyChecker {
     }
 
     fn warn_unknown_migration_disabled_checks(&self, disabled_checks: &[String], source: &str) {
+        let mut warned_names = Vec::new();
+
         for name in disabled_checks {
-            if !self.known_check_names.iter().any(|known| known == name) {
+            let name = name.as_str();
+            if warned_names.contains(&name) {
+                continue;
+            }
+            warned_names.push(name);
+
+            if !self
+                .known_check_names
+                .iter()
+                .any(|known| known.as_str() == name)
+            {
                 eprintln!(
                     "Warning: Unknown check name '{name}' in {source}. Run --list-checks to see available checks."
                 );

--- a/src/scripting.rs
+++ b/src/scripting.rs
@@ -625,6 +625,7 @@ mod tests {
         let ctx = crate::checks::MigrationContext {
             run_in_transaction: false,
             no_transaction_hint: "",
+            ..crate::checks::MigrationContext::default()
         };
         let violations = run_script_with_ctx(
             r#"
@@ -647,6 +648,7 @@ mod tests {
         let ctx = crate::checks::MigrationContext {
             run_in_transaction: true,
             no_transaction_hint: "Add -- diesel:no-transaction to the migration file.",
+            ..crate::checks::MigrationContext::default()
         };
         let violations = run_script_with_ctx(
             r#"

--- a/tests/diesel_adapter_test.rs
+++ b/tests/diesel_adapter_test.rs
@@ -159,3 +159,41 @@ fn test_diesel_no_separator_timestamp() {
     );
     assert!(results[0].0.contains("20240101000000_create_users"));
 }
+
+#[test]
+fn test_diesel_metadata_can_disable_checks_for_one_migration() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let migration_dir = temp_dir.path().join("2024_01_01_000000_test");
+    fs::create_dir(&migration_dir).unwrap();
+    fs::write(
+        migration_dir.join("metadata.toml"),
+        r#"
+disable_checks = ["AddColumnCheck"]
+"#,
+    )
+    .unwrap();
+    fs::write(
+        migration_dir.join("up.sql"),
+        "ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;",
+    )
+    .unwrap();
+
+    let config = Config {
+        framework: "diesel".to_string(),
+        enable_checks: vec![
+            "AddColumnCheck".to_string(),
+            "IdempotencyAlterCheck".to_string(),
+        ],
+        ..Default::default()
+    };
+    let results = SafetyChecker::with_config(config)
+        .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].1.len(), 1);
+    assert_eq!(
+        results[0].1[0].1.operation,
+        "ADD COLUMN without IF NOT EXISTS"
+    );
+}

--- a/tests/safety_assured_test.rs
+++ b/tests/safety_assured_test.rs
@@ -264,6 +264,46 @@ ALTER TABLE users ADD COLUMN name VARCHAR(255);
 }
 
 #[test]
+fn test_per_migration_disable_directive_skips_only_named_check() {
+    let checker = SafetyChecker::with_config(Config {
+        enable_checks: vec![
+            "AddColumnCheck".to_string(),
+            "IdempotencyAlterCheck".to_string(),
+        ],
+        ..Default::default()
+    });
+    let sql = r"
+-- diesel-guard:disable AddColumnCheck
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+    ";
+
+    let violations = checker.check_sql(sql).unwrap();
+    assert_eq!(violations.len(), 1);
+    assert_eq!(
+        violations[0].1.operation,
+        "ADD COLUMN without IF NOT EXISTS"
+    );
+}
+
+#[test]
+fn test_per_migration_disable_directive_accepts_multiple_checks() {
+    let checker = SafetyChecker::with_config(Config {
+        enable_checks: vec![
+            "AddColumnCheck".to_string(),
+            "IdempotencyAlterCheck".to_string(),
+        ],
+        ..Default::default()
+    });
+    let sql = r"
+-- diesel-guard:disable AddColumnCheck, IdempotencyAlterCheck
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+    ";
+
+    let violations = checker.check_sql(sql).unwrap();
+    assert_eq!(violations.len(), 0);
+}
+
+#[test]
 fn test_nested_blocks() {
     let checker = SafetyChecker::new();
     let sql = r"

--- a/tests/sqlx_adapter_test.rs
+++ b/tests/sqlx_adapter_test.rs
@@ -197,3 +197,35 @@ fn test_sqlx_check_down_suffix_format() {
     assert!(paths.iter().any(|p| p.contains(".up.sql")));
     assert!(paths.iter().any(|p| p.contains(".down.sql")));
 }
+
+#[test]
+fn test_sqlx_file_directive_can_disable_checks_for_one_migration() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    fs::write(
+        temp_dir.path().join("1_test.up.sql"),
+        r"
+-- diesel-guard:disable AddColumnCheck
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+",
+    )
+    .unwrap();
+
+    let config = Config {
+        framework: "sqlx".to_string(),
+        enable_checks: vec![
+            "AddColumnCheck".to_string(),
+            "IdempotencyAlterCheck".to_string(),
+        ],
+        ..Default::default()
+    };
+    let results = SafetyChecker::with_config(config)
+        .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].1.len(), 1);
+    assert_eq!(
+        results[0].1[0].1.operation,
+        "ADD COLUMN without IF NOT EXISTS"
+    );
+}


### PR DESCRIPTION
## What does this PR do?

Closes #174.

Adds migration-scoped disabling for specific checks, so users can suppress a known-safe check without suppressing every check in the migration.

Today, `safety-assured` blocks are useful when a migration has been manually reviewed, but they suppress all built-in and custom checks for the wrapped statements. This adds a narrower escape hatch:

```sql
-- diesel-guard:disable AddColumnCheck
ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
```

Other checks still run on the same migration. For example, the SQL above can still be flagged by `IdempotencyAlterCheck` if it is missing `IF NOT EXISTS`.

This PR also supports Diesel directory migration metadata:

```toml
disable_checks = ["AddColumnCheck"]
```

Unknown migration-scoped check names emit a warning, matching the existing behavior for global `disable_checks`, `enable_checks`, and `warn_checks` config.

## Testing

Ran the full local CI pipeline:

```sh
just ci
```

This includes:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo doc --no-deps`
- `cargo auditable build --release`
- `cargo test --all-features`
- `cargo deny check`
- `cargo audit`

Notes from local CI:

- `cargo doc` reports an existing rustdoc warning in `src/checks/pg_helpers.rs` for `"<unnamed>"`.
- `cargo deny check` reports existing duplicate dependency warnings.
- Both commands exit successfully and the overall `just ci` pipeline passes.

## Checklist

- [x] Relevant issue assigned under the `Development` section (not applicable: this repository has no Projects board)
- [x] Docs updated (`README.md`, `docs/src/safety-assured.md`, `docs/src/configuration.md`, `diesel-guard.toml.example`)
- [x] One feature per PR
- [x] No unrelated changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-migration suppression of specific safety checks using `-- diesel-guard:disable <CheckName>` directives or Diesel `metadata.toml` settings; supports disabling multiple checks via comma-separated values.
* **Bug Fixes**
  * Disabled checks are now filtered out during evaluation so they cannot produce violations for the targeted migration.
* **Documentation**
  * Expanded guidance with examples for disabling one or multiple checks for a single migration.
* **Tests**
  * Added integration and unit tests verifying per-migration disable behavior across SQLx and Diesel workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->