### PR TITLE
Add DDL timeout safety check

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -18,6 +18,7 @@
   - [Create Table with SERIAL](checks/create-table-serial.md)
   - [Creating an Extension](checks/creating-extension.md)
   - [Creating a Table without Primary Key](checks/create-table-without-pk.md)
+  - [DDL Timeouts](checks/ddl-timeouts.md)
   - [Domain CHECK Constraint](checks/add-domain-check-constraint.md)
   - [Dropping a Column](checks/dropping-column.md)
   - [Dropping a Constraint](checks/dropping-constraint.md)

--- a/docs/src/checks/ddl-timeouts.md
+++ b/docs/src/checks/ddl-timeouts.md
@@ -1,0 +1,41 @@
+# DDL Timeouts
+
+**Check name:** `DdlTimeoutCheck`
+
+**Lock type:** Applies before DDL that can wait on locks or run for a long time
+
+## Bad
+
+Running DDL without timeouts can leave a migration waiting indefinitely for a lock or a long-running statement. While it waits, later application queries can queue behind the migration and amplify the outage.
+
+```sql
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+```
+
+## Good
+
+Set both `lock_timeout` and `statement_timeout` before DDL:
+
+```sql
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+```
+
+`lock_timeout` makes the migration fail fast when it cannot acquire a lock. `statement_timeout` bounds the overall statement runtime.
+
+## Covered DDL
+
+This check is intentionally broad. It applies to schema-changing PostgreSQL DDL, including table, type, enum, domain, sequence, index, view, materialized view, trigger, rule, policy, function, extension, schema, database, foreign data wrapper, foreign table, user mapping, operator class/family, statistics, tablespace, `TRUNCATE`, `REINDEX`, and `REFRESH MATERIALIZED VIEW` statements.
+
+`SET LOCAL` also satisfies this check for transaction-wrapped migrations:
+
+```sql
+SET LOCAL lock_timeout = '2s';
+SET LOCAL statement_timeout = '60s';
+ALTER TABLE users ADD COLUMN admin BOOLEAN;
+```
+
+Only non-disabled timeout values count. Values such as `0`, `'0'`, and `'0ms'` disable PostgreSQL timeouts and will still be reported. `RESET`, `RESET ALL`, and `SET ... DEFAULT` also clear timeout state for later DDL.
+
+Teams that configure these timeouts at the connection or role level can disable this check in `diesel-guard.toml`.

--- a/docs/src/checks/ddl-timeouts.md
+++ b/docs/src/checks/ddl-timeouts.md
@@ -26,7 +26,7 @@ ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
 
 ## Covered DDL
 
-This check is intentionally broad. It applies to schema-changing PostgreSQL DDL, including table, type, enum, domain, sequence, index, view, materialized view, trigger, rule, policy, function, extension, schema, database, foreign data wrapper, foreign table, user mapping, operator class/family, statistics, tablespace, `TRUNCATE`, `REINDEX`, and `REFRESH MATERIALIZED VIEW` statements.
+This check is intentionally broad. It applies to schema-changing PostgreSQL DDL, including table, type, enum, domain, sequence, index, view, materialized view, trigger, rule, policy, function, extension, schema, database, foreign data wrapper, foreign table, user mapping, operator class/family, statistics, tablespace, publication, subscription, role, privilege, cast, conversion, transform, collation, text search, comment, security label, `TRUNCATE`, `REINDEX`, and `REFRESH MATERIALIZED VIEW` statements.
 
 `SET LOCAL` also satisfies this check for transaction-wrapped migrations:
 
@@ -37,5 +37,7 @@ ALTER TABLE users ADD COLUMN admin BOOLEAN;
 ```
 
 Only non-disabled timeout values count. Values such as `0`, `'0'`, and `'0ms'` disable PostgreSQL timeouts and will still be reported. `RESET`, `RESET ALL`, and `SET ... DEFAULT` also clear timeout state for later DDL.
+
+The timeout parser rejects common disabled zero values, but it does not evaluate every PostgreSQL interval expression. Prefer simple, explicit nonzero values such as `'2s'` and `'60s'`.
 
 Teams that configure these timeouts at the connection or role level can disable this check in `diesel-guard.toml`.

--- a/docs/src/checks/overview.md
+++ b/docs/src/checks/overview.md
@@ -14,6 +14,7 @@ diesel-guard ships safety checks covering the most common Postgres migration haz
 | [CHAR Fields](char-field.md) | `CHAR`/`CHARACTER` column types | — (best practice) |
 | [Create Table with SERIAL](create-table-serial.md) | `SERIAL/BIGSERIAL/SMALLSERIAL` in `CREATE TABLE` | — (best practice) |
 | [Creating an Extension](creating-extension.md) | `CREATE EXTENSION` | — (requires superuser) |
+| [DDL Timeouts](ddl-timeouts.md) | DDL before `lock_timeout` and `statement_timeout` are set | Applies to DDL lock waits and statement runtime |
 | [Domain CHECK Constraint](add-domain-check-constraint.md) | `ALTER DOMAIN ... ADD CONSTRAINT ... CHECK` without `NOT VALID` | ACCESS EXCLUSIVE |
 | [Dropping a Column](dropping-column.md) | `ALTER TABLE ... DROP COLUMN` | ACCESS EXCLUSIVE |
 | [Dropping a Constraint](dropping-constraint.md) | Unnamed `UNIQUE`/`FOREIGN KEY`/`CHECK` constraints | — (best practice) |

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -74,6 +74,7 @@ Use these names in `disable_checks` (blacklist), `enable_checks` (whitelist), or
 | `CharTypeCheck` | CHAR/CHARACTER column types |
 | `CreateExtensionCheck` | CREATE EXTENSION |
 | `CreateTableSerialCheck` | CREATE TABLE with SERIAL |
+| `DdlTimeoutCheck` | DDL before `lock_timeout` and `statement_timeout` are set |
 | `DropColumnCheck` | DROP COLUMN |
 | `DropDatabaseCheck` | DROP DATABASE |
 | `DropIndexCheck` | DROP INDEX without CONCURRENTLY; CONCURRENTLY inside a transaction |

--- a/src/checks/ddl_timeout.rs
+++ b/src/checks/ddl_timeout.rs
@@ -548,6 +548,7 @@ ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
             "ALTER ROLE app_user SET search_path = public;",
             "DROP ROLE app_user;",
             "GRANT SELECT ON TABLE users TO app_user;",
+            "REVOKE SELECT ON TABLE users FROM app_user;",
             "ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO app_user;",
             "COMMENT ON TABLE users IS 'customer records';",
             "SECURITY LABEL FOR selinux ON TABLE users IS 'system_u:object_r:sepgsql_table_t:s0';",

--- a/src/checks/ddl_timeout.rs
+++ b/src/checks/ddl_timeout.rs
@@ -1,0 +1,522 @@
+//! Detection for DDL before lock_timeout and statement_timeout are configured.
+//!
+//! This check is sequence-aware: it tracks `SET lock_timeout` and
+//! `SET statement_timeout` statements before DDL in the same SQL input.
+
+use crate::ViolationList;
+use crate::checks::pg_helpers::NodeEnum;
+use crate::checks::{Config, MigrationContext, StatementContext, StatementListCheck};
+use crate::violation::Violation;
+use pg_query::protobuf::{VariableSetKind, a_const};
+
+pub struct DdlTimeoutCheck;
+
+impl StatementListCheck for DdlTimeoutCheck {
+    fn check(
+        &self,
+        statements: &[StatementContext<'_>],
+        _config: &Config,
+        _ctx: &MigrationContext,
+    ) -> ViolationList {
+        let mut has_lock_timeout = false;
+        let mut has_statement_timeout = false;
+        let mut violations = Vec::new();
+
+        for stmt in statements {
+            match timeout_transition(stmt.node) {
+                Some(TimeoutTransition::Set(TimeoutSetting::LockTimeout)) => {
+                    has_lock_timeout = true;
+                    continue;
+                }
+                Some(TimeoutTransition::Set(TimeoutSetting::StatementTimeout)) => {
+                    has_statement_timeout = true;
+                    continue;
+                }
+                Some(TimeoutTransition::Clear(TimeoutSetting::LockTimeout)) => {
+                    has_lock_timeout = false;
+                    continue;
+                }
+                Some(TimeoutTransition::Clear(TimeoutSetting::StatementTimeout)) => {
+                    has_statement_timeout = false;
+                    continue;
+                }
+                Some(TimeoutTransition::ClearAll) => {
+                    has_lock_timeout = false;
+                    has_statement_timeout = false;
+                    continue;
+                }
+                None => {}
+            }
+
+            if stmt.ignored || !is_ddl(stmt.node) || (has_lock_timeout && has_statement_timeout) {
+                continue;
+            }
+
+            violations.push((
+                stmt.line,
+                Violation::new(
+                    "DDL without lock_timeout/statement_timeout",
+                    missing_timeout_problem(has_lock_timeout, has_statement_timeout),
+                    r"Set both lock_timeout and statement_timeout before running DDL:
+
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+
+This makes migrations fail fast instead of waiting indefinitely on locks or long-running statements.",
+                ),
+            ));
+        }
+
+        violations
+    }
+}
+
+enum TimeoutSetting {
+    LockTimeout,
+    StatementTimeout,
+}
+
+enum TimeoutTransition {
+    Set(TimeoutSetting),
+    Clear(TimeoutSetting),
+    ClearAll,
+}
+
+fn timeout_transition(node: &NodeEnum) -> Option<TimeoutTransition> {
+    let NodeEnum::VariableSetStmt(stmt) = node else {
+        return None;
+    };
+
+    let setting = if stmt.name.eq_ignore_ascii_case("lock_timeout") {
+        Some(TimeoutSetting::LockTimeout)
+    } else if stmt.name.eq_ignore_ascii_case("statement_timeout") {
+        Some(TimeoutSetting::StatementTimeout)
+    } else {
+        None
+    };
+
+    match VariableSetKind::try_from(stmt.kind).ok()? {
+        VariableSetKind::VarSetValue => {
+            let setting = setting?;
+            if timeout_value_is_disabled(stmt.args.first()) {
+                Some(TimeoutTransition::Clear(setting))
+            } else {
+                Some(TimeoutTransition::Set(setting))
+            }
+        }
+        VariableSetKind::VarSetDefault | VariableSetKind::VarReset => {
+            setting.map(TimeoutTransition::Clear)
+        }
+        VariableSetKind::VarResetAll => Some(TimeoutTransition::ClearAll),
+        VariableSetKind::Undefined
+        | VariableSetKind::VarSetCurrent
+        | VariableSetKind::VarSetMulti => None,
+    }
+}
+
+fn timeout_value_is_disabled(value: Option<&pg_query::protobuf::Node>) -> bool {
+    let Some(NodeEnum::AConst(value)) = value.and_then(|node| node.node.as_ref()) else {
+        return false;
+    };
+
+    match &value.val {
+        Some(a_const::Val::Ival(value)) => value.ival == 0,
+        Some(a_const::Val::Fval(value)) => is_zeroish_timeout_literal(&value.fval),
+        Some(a_const::Val::Sval(value)) => is_zeroish_timeout_literal(&value.sval),
+        _ => false,
+    }
+}
+
+fn is_zeroish_timeout_literal(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return false;
+    }
+
+    let unit_start = normalized
+        .char_indices()
+        .find(|(_, ch)| {
+            !(ch.is_ascii_digit() || matches!(ch, '.' | '+' | '-' | ' ' | '\t' | '\n' | '\r'))
+        })
+        .map_or(normalized.len(), |(index, _)| index);
+
+    let (amount, unit) = normalized.split_at(unit_start);
+    let is_zero = amount
+        .trim()
+        .parse::<f64>()
+        .is_ok_and(|amount| amount == 0.0);
+
+    is_zero
+        && (unit.trim().is_empty()
+            || matches!(
+                unit.trim(),
+                "us" | "usec"
+                    | "usecs"
+                    | "microsecond"
+                    | "microseconds"
+                    | "ms"
+                    | "msec"
+                    | "msecs"
+                    | "millisecond"
+                    | "milliseconds"
+                    | "s"
+                    | "sec"
+                    | "secs"
+                    | "second"
+                    | "seconds"
+                    | "min"
+                    | "mins"
+                    | "minute"
+                    | "minutes"
+                    | "h"
+                    | "hr"
+                    | "hrs"
+                    | "hour"
+                    | "hours"
+                    | "d"
+                    | "day"
+                    | "days"
+            ))
+}
+
+fn is_ddl(node: &NodeEnum) -> bool {
+    matches!(
+        node,
+        NodeEnum::AlterDomainStmt(_)
+            | NodeEnum::AlterDatabaseRefreshCollStmt(_)
+            | NodeEnum::AlterDatabaseSetStmt(_)
+            | NodeEnum::AlterDatabaseStmt(_)
+            | NodeEnum::AlterEventTrigStmt(_)
+            | NodeEnum::AlterEnumStmt(_)
+            | NodeEnum::AlterExtensionStmt(_)
+            | NodeEnum::AlterExtensionContentsStmt(_)
+            | NodeEnum::AlterFdwStmt(_)
+            | NodeEnum::AlterForeignServerStmt(_)
+            | NodeEnum::AlterFunctionStmt(_)
+            | NodeEnum::AlterObjectSchemaStmt(_)
+            | NodeEnum::AlterOwnerStmt(_)
+            | NodeEnum::AlterPolicyStmt(_)
+            | NodeEnum::AlterOperatorStmt(_)
+            | NodeEnum::AlterOpFamilyStmt(_)
+            | NodeEnum::AlterSeqStmt(_)
+            | NodeEnum::AlterStatsStmt(_)
+            | NodeEnum::AlterTableStmt(_)
+            | NodeEnum::AlterTableMoveAllStmt(_)
+            | NodeEnum::AlterTableSpaceOptionsStmt(_)
+            | NodeEnum::AlterTypeStmt(_)
+            | NodeEnum::AlterUserMappingStmt(_)
+            | NodeEnum::CompositeTypeStmt(_)
+            | NodeEnum::CreatedbStmt(_)
+            | NodeEnum::CreateAmStmt(_)
+            | NodeEnum::CreateDomainStmt(_)
+            | NodeEnum::CreateEnumStmt(_)
+            | NodeEnum::CreateEventTrigStmt(_)
+            | NodeEnum::CreateExtensionStmt(_)
+            | NodeEnum::CreateFdwStmt(_)
+            | NodeEnum::CreateForeignServerStmt(_)
+            | NodeEnum::CreateForeignTableStmt(_)
+            | NodeEnum::CreateFunctionStmt(_)
+            | NodeEnum::CreateOpClassStmt(_)
+            | NodeEnum::CreateOpFamilyStmt(_)
+            | NodeEnum::CreatePlangStmt(_)
+            | NodeEnum::CreatePolicyStmt(_)
+            | NodeEnum::CreateRangeStmt(_)
+            | NodeEnum::CreateSchemaStmt(_)
+            | NodeEnum::CreateSeqStmt(_)
+            | NodeEnum::CreateStatsStmt(_)
+            | NodeEnum::CreateStmt(_)
+            | NodeEnum::CreateTableAsStmt(_)
+            | NodeEnum::CreateTableSpaceStmt(_)
+            | NodeEnum::CreateTrigStmt(_)
+            | NodeEnum::CreateUserMappingStmt(_)
+            | NodeEnum::DropStmt(_)
+            | NodeEnum::DropdbStmt(_)
+            | NodeEnum::DropTableSpaceStmt(_)
+            | NodeEnum::DropUserMappingStmt(_)
+            | NodeEnum::DefineStmt(_)
+            | NodeEnum::ImportForeignSchemaStmt(_)
+            | NodeEnum::IndexStmt(_)
+            | NodeEnum::RefreshMatViewStmt(_)
+            | NodeEnum::ReindexStmt(_)
+            | NodeEnum::RenameStmt(_)
+            | NodeEnum::RuleStmt(_)
+            | NodeEnum::TruncateStmt(_)
+            | NodeEnum::ViewStmt(_)
+    )
+}
+
+fn missing_timeout_problem(has_lock_timeout: bool, has_statement_timeout: bool) -> String {
+    let (missing, verb) = match (has_lock_timeout, has_statement_timeout) {
+        (false, false) => ("lock_timeout and statement_timeout", "are"),
+        (false, true) => ("lock_timeout", "is"),
+        (true, false) => ("statement_timeout", "is"),
+        (true, true) => unreachable!("no missing timeout when both are set"),
+    };
+
+    format!(
+        "DDL runs before {missing} {verb} configured. Without timeouts, migrations can wait \
+        indefinitely for locks or long-running statements, delaying production traffic."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checks::pg_helpers::extract_node;
+
+    fn check_sql(sql: &str) -> ViolationList {
+        let parsed = pg_query::parse(sql).unwrap();
+        let statements = parsed
+            .protobuf
+            .stmts
+            .iter()
+            .enumerate()
+            .filter_map(|(index, raw_stmt)| {
+                let node = extract_node(raw_stmt)?;
+                Some(StatementContext {
+                    node,
+                    line: index + 1,
+                    ignored: false,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        DdlTimeoutCheck.check(
+            &statements,
+            &Config::default(),
+            &MigrationContext::default(),
+        )
+    }
+
+    #[test]
+    fn test_detects_ddl_without_timeouts() {
+        let violations = check_sql("ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            violations[0].1.operation,
+            "DDL without lock_timeout/statement_timeout"
+        );
+        assert!(
+            violations[0]
+                .1
+                .problem
+                .contains("lock_timeout and statement_timeout")
+        );
+    }
+
+    #[test]
+    fn test_allows_ddl_after_both_timeouts() {
+        let violations = check_sql(
+            r"
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+        ",
+        );
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_detects_missing_statement_timeout() {
+        let violations = check_sql(
+            r"
+SET lock_timeout = '2s';
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+        ",
+        );
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].1.problem.contains("statement_timeout"));
+    }
+
+    #[test]
+    fn test_set_local_counts_as_timeout_assignment() {
+        let violations = check_sql(
+            r"
+SET LOCAL lock_timeout = '2s';
+SET LOCAL statement_timeout = '60s';
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+        ",
+        );
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_reset_does_not_count_as_timeout_assignment() {
+        let violations = check_sql(
+            r"
+RESET lock_timeout;
+SET statement_timeout = '60s';
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+        ",
+        );
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].1.problem.contains("lock_timeout"));
+    }
+
+    #[test]
+    fn test_reset_clears_previous_timeout_assignment() {
+        let violations = check_sql(
+            r"
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+RESET lock_timeout;
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+        ",
+        );
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].1.problem.contains("lock_timeout"));
+    }
+
+    #[test]
+    fn test_default_clears_previous_timeout_assignment() {
+        let violations = check_sql(
+            r"
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+SET statement_timeout = DEFAULT;
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+        ",
+        );
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].1.problem.contains("statement_timeout"));
+    }
+
+    #[test]
+    fn test_reset_all_clears_timeout_assignments() {
+        let violations = check_sql(
+            r"
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+RESET ALL;
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+        ",
+        );
+
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .1
+                .problem
+                .contains("lock_timeout and statement_timeout")
+        );
+    }
+
+    #[test]
+    fn test_zero_timeout_values_do_not_satisfy_check() {
+        let violations = check_sql(
+            r"
+SET lock_timeout = 0;
+SET statement_timeout = '0ms';
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+        ",
+        );
+
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .1
+                .problem
+                .contains("lock_timeout and statement_timeout")
+        );
+    }
+
+    #[test]
+    fn test_additional_zero_timeout_units_do_not_satisfy_check() {
+        for value in [
+            "0us",
+            "0 usecs",
+            "0 microseconds",
+            "0msec",
+            "0 seconds",
+            "0min",
+            "0 hours",
+            "0d",
+            "0 days",
+        ] {
+            let sql = format!(
+                r"
+SET lock_timeout = '{value}';
+SET statement_timeout = '60s';
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+        "
+            );
+
+            let violations = check_sql(&sql);
+
+            assert_eq!(violations.len(), 1, "expected {value:?} to be disabled");
+            assert!(violations[0].1.problem.contains("lock_timeout"));
+        }
+    }
+
+    #[test]
+    fn test_fractional_nonzero_timeout_values_satisfy_check() {
+        for value in ["0.5s", "0.001 seconds", "1ms", "100us", "1 day"] {
+            let sql = format!(
+                r"
+SET lock_timeout = '{value}';
+SET statement_timeout = '60s';
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+        "
+            );
+
+            let violations = check_sql(&sql);
+
+            assert_eq!(
+                violations.len(),
+                0,
+                "expected {value:?} to satisfy lock_timeout"
+            );
+        }
+    }
+
+    #[test]
+    fn test_zero_timeout_clears_previous_assignment() {
+        let violations = check_sql(
+            r"
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+SET lock_timeout = '0';
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+        ",
+        );
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].1.problem.contains("lock_timeout"));
+    }
+
+    #[test]
+    fn test_ignores_non_ddl() {
+        let violations = check_sql("UPDATE users SET active = false WHERE id = 1;");
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_detects_broad_ddl_statement_kinds_without_timeouts() {
+        for sql in [
+            "CREATE TYPE mood AS ENUM ('happy', 'sad');",
+            "CREATE TRIGGER users_updated BEFORE UPDATE ON users FOR EACH ROW EXECUTE FUNCTION touch_updated_at();",
+            "CREATE POLICY users_policy ON users USING (true);",
+            "ALTER POLICY users_policy ON users USING (false);",
+            "CREATE FUNCTION touch_updated_at() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;",
+            "ALTER FUNCTION touch_updated_at() OWNER TO postgres;",
+            "CREATE DATABASE analytics;",
+        ] {
+            let violations = check_sql(sql);
+
+            assert_eq!(violations.len(), 1, "expected DDL violation for {sql}");
+            assert_eq!(
+                violations[0].1.operation,
+                "DDL without lock_timeout/statement_timeout"
+            );
+        }
+    }
+}

--- a/src/checks/ddl_timeout.rs
+++ b/src/checks/ddl_timeout.rs
@@ -289,6 +289,7 @@ fn missing_timeout_problem(has_lock_timeout: bool, has_statement_timeout: bool) 
 mod tests {
     use super::*;
     use crate::checks::pg_helpers::extract_node;
+    use pg_query::protobuf::{AConst, Boolean, Float, Node, VariableSetStmt, node};
 
     fn check_sql(sql: &str) -> ViolationList {
         let parsed = pg_query::parse(sql).unwrap();
@@ -515,6 +516,50 @@ ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
 
         assert_eq!(violations.len(), 1);
         assert!(violations[0].1.problem.contains("lock_timeout"));
+    }
+
+    #[test]
+    fn test_timeout_parser_ignores_non_assignment_set_variants() {
+        for kind in [
+            VariableSetKind::Undefined,
+            VariableSetKind::VarSetCurrent,
+            VariableSetKind::VarSetMulti,
+        ] {
+            let stmt = NodeEnum::VariableSetStmt(VariableSetStmt {
+                kind: kind as i32,
+                name: "lock_timeout".to_string(),
+                args: vec![],
+                is_local: false,
+            });
+
+            assert!(timeout_transition(&stmt).is_none());
+        }
+    }
+
+    #[test]
+    fn test_timeout_disabled_parser_handles_edge_literals() {
+        assert!(!timeout_value_is_disabled(None));
+        assert!(!is_zeroish_timeout_literal(""));
+
+        let zero_float = Node {
+            node: Some(node::Node::AConst(AConst {
+                val: Some(a_const::Val::Fval(Float {
+                    fval: "0.0".to_string(),
+                })),
+                isnull: false,
+                location: 0,
+            })),
+        };
+        assert!(timeout_value_is_disabled(Some(&zero_float)));
+
+        let boolean = Node {
+            node: Some(node::Node::AConst(AConst {
+                val: Some(a_const::Val::Boolval(Boolean { boolval: false })),
+                isnull: false,
+                location: 0,
+            })),
+        };
+        assert!(!timeout_value_is_disabled(Some(&boolean)));
     }
 
     #[test]

--- a/src/checks/ddl_timeout.rs
+++ b/src/checks/ddl_timeout.rs
@@ -183,7 +183,9 @@ fn is_zeroish_timeout_literal(value: &str) -> bool {
 fn is_ddl(node: &NodeEnum) -> bool {
     matches!(
         node,
-        NodeEnum::AlterDomainStmt(_)
+        NodeEnum::AlterCollationStmt(_)
+            | NodeEnum::AlterDefaultPrivilegesStmt(_)
+            | NodeEnum::AlterDomainStmt(_)
             | NodeEnum::AlterDatabaseRefreshCollStmt(_)
             | NodeEnum::AlterDatabaseSetStmt(_)
             | NodeEnum::AlterDatabaseStmt(_)
@@ -201,14 +203,24 @@ fn is_ddl(node: &NodeEnum) -> bool {
             | NodeEnum::AlterOpFamilyStmt(_)
             | NodeEnum::AlterSeqStmt(_)
             | NodeEnum::AlterStatsStmt(_)
+            | NodeEnum::AlterSubscriptionStmt(_)
             | NodeEnum::AlterTableStmt(_)
             | NodeEnum::AlterTableMoveAllStmt(_)
             | NodeEnum::AlterTableSpaceOptionsStmt(_)
+            | NodeEnum::AlterTsdictionaryStmt(_)
+            | NodeEnum::AlterTsconfigurationStmt(_)
             | NodeEnum::AlterTypeStmt(_)
+            | NodeEnum::AlterSystemStmt(_)
+            | NodeEnum::AlterObjectDependsStmt(_)
             | NodeEnum::AlterUserMappingStmt(_)
+            | NodeEnum::AlterPublicationStmt(_)
+            | NodeEnum::AlterRoleStmt(_)
+            | NodeEnum::AlterRoleSetStmt(_)
             | NodeEnum::CompositeTypeStmt(_)
             | NodeEnum::CreatedbStmt(_)
             | NodeEnum::CreateAmStmt(_)
+            | NodeEnum::CreateCastStmt(_)
+            | NodeEnum::CreateConversionStmt(_)
             | NodeEnum::CreateDomainStmt(_)
             | NodeEnum::CreateEnumStmt(_)
             | NodeEnum::CreateEventTrigStmt(_)
@@ -221,26 +233,39 @@ fn is_ddl(node: &NodeEnum) -> bool {
             | NodeEnum::CreateOpFamilyStmt(_)
             | NodeEnum::CreatePlangStmt(_)
             | NodeEnum::CreatePolicyStmt(_)
+            | NodeEnum::CreatePublicationStmt(_)
             | NodeEnum::CreateRangeStmt(_)
+            | NodeEnum::CreateRoleStmt(_)
             | NodeEnum::CreateSchemaStmt(_)
             | NodeEnum::CreateSeqStmt(_)
             | NodeEnum::CreateStatsStmt(_)
             | NodeEnum::CreateStmt(_)
+            | NodeEnum::CreateSubscriptionStmt(_)
             | NodeEnum::CreateTableAsStmt(_)
             | NodeEnum::CreateTableSpaceStmt(_)
+            | NodeEnum::CreateTransformStmt(_)
             | NodeEnum::CreateTrigStmt(_)
             | NodeEnum::CreateUserMappingStmt(_)
+            | NodeEnum::CommentStmt(_)
             | NodeEnum::DropStmt(_)
             | NodeEnum::DropdbStmt(_)
+            | NodeEnum::DropOwnedStmt(_)
+            | NodeEnum::DropRoleStmt(_)
+            | NodeEnum::DropSubscriptionStmt(_)
             | NodeEnum::DropTableSpaceStmt(_)
             | NodeEnum::DropUserMappingStmt(_)
             | NodeEnum::DefineStmt(_)
+            | NodeEnum::GrantRoleStmt(_)
+            | NodeEnum::GrantStmt(_)
             | NodeEnum::ImportForeignSchemaStmt(_)
             | NodeEnum::IndexStmt(_)
             | NodeEnum::RefreshMatViewStmt(_)
             | NodeEnum::ReindexStmt(_)
+            | NodeEnum::ReassignOwnedStmt(_)
             | NodeEnum::RenameStmt(_)
+            | NodeEnum::ReplicaIdentityStmt(_)
             | NodeEnum::RuleStmt(_)
+            | NodeEnum::SecLabelStmt(_)
             | NodeEnum::TruncateStmt(_)
             | NodeEnum::ViewStmt(_)
     )
@@ -509,6 +534,23 @@ ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
             "CREATE FUNCTION touch_updated_at() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;",
             "ALTER FUNCTION touch_updated_at() OWNER TO postgres;",
             "CREATE DATABASE analytics;",
+            "CREATE PUBLICATION pub_all FOR ALL TABLES;",
+            "ALTER PUBLICATION pub_all SET (publish = 'insert, update');",
+            "CREATE SUBSCRIPTION sub CONNECTION 'host=localhost' PUBLICATION pub WITH (connect = false);",
+            "ALTER SUBSCRIPTION sub DISABLE;",
+            "DROP SUBSCRIPTION sub;",
+            "CREATE CAST (text AS int4) WITH INOUT AS ASSIGNMENT;",
+            "CREATE DEFAULT CONVERSION myconv FOR 'UTF8' TO 'LATIN1' FROM utf8_to_latin1;",
+            "CREATE TRANSFORM FOR hstore LANGUAGE plpgsql (FROM SQL WITH FUNCTION hstore_recv(internal), TO SQL WITH FUNCTION hstore_send(hstore));",
+            "ALTER COLLATION \"C\" REFRESH VERSION;",
+            "ALTER TEXT SEARCH DICTIONARY english_stem (StopWords = english);",
+            "CREATE ROLE app_user;",
+            "ALTER ROLE app_user SET search_path = public;",
+            "DROP ROLE app_user;",
+            "GRANT SELECT ON TABLE users TO app_user;",
+            "ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO app_user;",
+            "COMMENT ON TABLE users IS 'customer records';",
+            "SECURITY LABEL FOR selinux ON TABLE users IS 'system_u:object_r:sepgsql_table_t:s0';",
         ] {
             let violations = check_sql(sql);
 

--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -15,6 +15,7 @@ mod char_type;
 mod create_extension;
 mod create_table_serial;
 mod create_table_without_pk;
+mod ddl_timeout;
 mod drop_column;
 mod drop_database;
 mod drop_index;
@@ -58,6 +59,7 @@ pub use char_type::CharTypeCheck;
 pub use create_extension::CreateExtensionCheck;
 pub use create_table_serial::CreateTableSerialCheck;
 pub use create_table_without_pk::CreateTableWithoutPkCheck;
+pub use ddl_timeout::DdlTimeoutCheck;
 pub use drop_column::DropColumnCheck;
 pub use drop_database::DropDatabaseCheck;
 pub use drop_index::DropIndexCheck;
@@ -111,7 +113,7 @@ use crate::checks::add_check_constraint::AddCheckConstraintCheck;
 /// This avoids maintaining a manual list that can drift from the actual checks.
 static BUILTIN_CHECK_NAMES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
     let registry = Registry::new();
-    registry.checks.iter().map(|c| c.name()).collect()
+    registry.active_check_names()
 });
 
 /// Trait for implementing safety checks on SQL statements
@@ -127,9 +129,34 @@ pub trait Check: Send + Sync {
     fn check(&self, node: &NodeEnum, config: &Config, ctx: &MigrationContext) -> Vec<Violation>;
 }
 
+/// Trait for safety checks that need ordered statement-list context.
+pub trait StatementListCheck: Send + Sync {
+    /// The check's name, used for config-based disabling.
+    fn name(&self) -> &'static str {
+        let full = std::any::type_name::<Self>();
+        full.rsplit("::").next().unwrap_or(full)
+    }
+
+    /// Run the check across the ordered statements in one SQL input.
+    fn check(
+        &self,
+        statements: &[StatementContext<'_>],
+        config: &Config,
+        ctx: &MigrationContext,
+    ) -> ViolationList;
+}
+
+/// Statement metadata shared with sequence-aware checks.
+pub struct StatementContext<'a> {
+    pub node: &'a NodeEnum,
+    pub line: usize,
+    pub ignored: bool,
+}
+
 /// Registry of all available checks
 pub struct Registry {
     checks: Vec<Box<dyn Check>>,
+    statement_list_checks: Vec<Box<dyn StatementListCheck>>,
 }
 
 impl Registry {
@@ -140,7 +167,10 @@ impl Registry {
 
     /// Create registry with configuration-based filtering
     pub fn with_config(config: &Config) -> Self {
-        let mut registry = Self { checks: vec![] };
+        let mut registry = Self {
+            checks: vec![],
+            statement_list_checks: vec![],
+        };
         registry.register_enabled_checks(config);
         registry
     }
@@ -164,6 +194,7 @@ impl Registry {
         self.register_check(config, CreateExtensionCheck);
         self.register_check(config, CreateTableSerialCheck);
         self.register_check(config, CreateTableWithoutPkCheck);
+        self.register_statement_list_check(config, DdlTimeoutCheck);
         self.register_check(config, DropColumnCheck);
         self.register_check(config, DropDatabaseCheck);
         self.register_check(config, DropIndexCheck);
@@ -194,8 +225,12 @@ impl Registry {
     }
 
     /// Return the names of all currently active checks (built-in + custom, minus disabled).
-    pub fn active_check_names(&self) -> Vec<&str> {
-        self.checks.iter().map(|c| c.name()).collect()
+    pub fn active_check_names(&self) -> Vec<&'static str> {
+        self.checks
+            .iter()
+            .map(|c| c.name())
+            .chain(self.statement_list_checks.iter().map(|c| c.name()))
+            .collect()
     }
 
     /// Register a check if it's enabled in configuration
@@ -204,6 +239,49 @@ impl Registry {
             return;
         }
         self.checks.push(Box::new(check));
+    }
+
+    /// Register a statement-list check if it's enabled in configuration.
+    fn register_statement_list_check(
+        &mut self,
+        config: &Config,
+        check: impl StatementListCheck + 'static,
+    ) {
+        if !config.is_check_enabled(check.name()) {
+            return;
+        }
+        self.statement_list_checks.push(Box::new(check));
+    }
+
+    /// Check the ordered statement list against all registered statement-list checks.
+    fn check_statement_list(
+        &self,
+        statements: &[StatementContext<'_>],
+        config: &Config,
+        ctx: &MigrationContext,
+    ) -> ViolationList {
+        use crate::violation::Severity;
+
+        self.statement_list_checks
+            .iter()
+            .filter(|check| !ctx.disables_check(check.name()))
+            .flat_map(|check| {
+                let severity = if config.is_check_warning(check.name()) {
+                    Severity::Warning
+                } else {
+                    Severity::Error
+                };
+                check
+                    .check(statements, config, ctx)
+                    .into_iter()
+                    .map(move |(line, v)| {
+                        (
+                            line,
+                            v.with_severity(severity).with_check_name(check.name()),
+                        )
+                    })
+            })
+            .collect()
     }
 
     /// Check a single AST node against all registered checks
@@ -256,24 +334,32 @@ impl Registry {
         // statement. Use the scanner to get accurate token positions.
         let token_starts = non_comment_token_starts(sql);
 
-        let mut violations = Vec::new();
+        let statement_contexts = stmts
+            .iter()
+            .filter_map(|raw_stmt| {
+                let node = extract_node(raw_stmt)?;
+                let offset = first_token_at_or_after(
+                    &token_starts,
+                    usize::try_from(raw_stmt.stmt_location).unwrap_or(0),
+                );
+                let line = byte_offset_to_line(sql, offset);
 
-        for raw_stmt in stmts {
-            let Some(node) = extract_node(raw_stmt) else {
-                continue;
-            };
+                Some(StatementContext {
+                    node,
+                    line,
+                    ignored: ignored_lines.contains(&line),
+                })
+            })
+            .collect::<Vec<_>>();
 
-            let offset = first_token_at_or_after(
-                &token_starts,
-                usize::try_from(raw_stmt.stmt_location).unwrap_or(0),
-            );
-            let stmt_line = byte_offset_to_line(sql, offset);
+        let mut violations = self.check_statement_list(&statement_contexts, config, ctx);
 
-            if !ignored_lines.contains(&stmt_line) {
+        for stmt in statement_contexts {
+            if !stmt.ignored {
                 violations.extend(
-                    self.check_node(node, config, ctx)
+                    self.check_node(stmt.node, config, ctx)
                         .into_iter()
-                        .map(|v| (stmt_line, v)),
+                        .map(|v| (stmt.line, v)),
                 );
             }
         }
@@ -339,14 +425,20 @@ mod tests {
     #[test]
     fn test_registry_creation() {
         let registry = Registry::new();
-        assert_eq!(registry.checks.len(), Registry::builtin_check_names().len());
+        assert_eq!(
+            registry.active_check_names().len(),
+            Registry::builtin_check_names().len()
+        );
     }
 
     #[test]
     fn test_registry_includes_all_checks_when_no_version_set() {
         let registry = Registry::new();
         assert!(registry.active_check_names().contains(&"AddColumnCheck"));
-        assert_eq!(registry.checks.len(), Registry::builtin_check_names().len());
+        assert_eq!(
+            registry.active_check_names().len(),
+            Registry::builtin_check_names().len()
+        );
     }
 
     #[test]
@@ -370,7 +462,7 @@ mod tests {
 
         let registry = Registry::with_config(&config);
         assert_eq!(
-            registry.checks.len(),
+            registry.active_check_names().len(),
             Registry::builtin_check_names().len() - 1
         );
     }
@@ -384,7 +476,7 @@ mod tests {
 
         let registry = Registry::with_config(&config);
         assert_eq!(
-            registry.checks.len(),
+            registry.active_check_names().len(),
             Registry::builtin_check_names().len() - 2
         );
     }
@@ -400,7 +492,7 @@ mod tests {
         };
 
         let registry = Registry::with_config(&config);
-        assert_eq!(registry.checks.len(), 0);
+        assert_eq!(registry.active_check_names().len(), 0);
     }
 
     #[test]

--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -247,10 +247,9 @@ impl Registry {
         config: &Config,
         check: impl StatementListCheck + 'static,
     ) {
-        if !config.is_check_enabled(check.name()) {
-            return;
+        if config.is_check_enabled(check.name()) {
+            self.statement_list_checks.push(Box::new(check));
         }
-        self.statement_list_checks.push(Box::new(check));
     }
 
     /// Check the ordered statement list against all registered statement-list checks.
@@ -465,6 +464,20 @@ mod tests {
             registry.active_check_names().len(),
             Registry::builtin_check_names().len() - 1
         );
+    }
+
+    #[test]
+    fn test_registry_with_disabled_statement_list_check() {
+        let config = Config {
+            disable_checks: vec!["DdlTimeoutCheck".to_string()],
+            ..Default::default()
+        };
+
+        let registry = Registry::with_config(&config);
+        let active = registry.active_check_names();
+
+        assert!(!active.contains(&"DdlTimeoutCheck"));
+        assert_eq!(active.len(), Registry::builtin_check_names().len() - 1);
     }
 
     #[test]

--- a/src/safety_checker.rs
+++ b/src/safety_checker.rs
@@ -309,7 +309,10 @@ mod tests {
 
     #[test]
     fn test_reindex_without_concurrently_detected() {
-        let checker = SafetyChecker::new();
+        let checker = SafetyChecker::with_config(Config {
+            enable_checks: vec!["ReindexCheck".to_string()],
+            ..Default::default()
+        });
         let sql = "REINDEX INDEX idx_users_email;";
         let violations = checker.check_sql(sql).unwrap();
         assert_eq!(violations.len(), 1);
@@ -318,7 +321,10 @@ mod tests {
 
     #[test]
     fn test_reindex_table_without_concurrently_detected() {
-        let checker = SafetyChecker::new();
+        let checker = SafetyChecker::with_config(Config {
+            enable_checks: vec!["ReindexCheck".to_string()],
+            ..Default::default()
+        });
         let sql = "REINDEX TABLE users;";
         let violations = checker.check_sql(sql).unwrap();
         assert_eq!(violations.len(), 1);
@@ -329,7 +335,10 @@ mod tests {
     fn test_reindex_concurrently_in_transaction_detected() {
         // check_sql uses MigrationContext::default() (run_in_transaction=true),
         // so REINDEX CONCURRENTLY is flagged as requiring no-transaction context.
-        let checker = SafetyChecker::new();
+        let checker = SafetyChecker::with_config(Config {
+            enable_checks: vec!["ReindexCheck".to_string()],
+            ..Default::default()
+        });
         let sql = "REINDEX INDEX CONCURRENTLY idx_users_email;";
         let violations = checker.check_sql(sql).unwrap();
         assert_eq!(violations.len(), 1);
@@ -347,14 +356,21 @@ mod tests {
         };
         let checker = SafetyChecker::with_config(config);
 
-        let sql = "REINDEX INDEX idx_users_email;";
+        let sql = r"
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+REINDEX INDEX idx_users_email;
+        ";
         let violations = checker.check_sql(sql).unwrap();
         assert_eq!(violations.len(), 0);
     }
 
     #[test]
     fn test_multiple_reindex_violations() {
-        let checker = SafetyChecker::new();
+        let checker = SafetyChecker::with_config(Config {
+            enable_checks: vec!["ReindexCheck".to_string()],
+            ..Default::default()
+        });
         let sql = r"
             REINDEX INDEX idx_users_email;
             REINDEX TABLE posts;
@@ -491,7 +507,10 @@ mod tests {
 
     #[test]
     fn test_buffer_input_multiple_lines() {
-        let checker: SafetyChecker = SafetyChecker::new();
+        let checker = SafetyChecker::with_config(Config {
+            enable_checks: vec!["ReindexCheck".to_string()],
+            ..Default::default()
+        });
         let input_data = r"
             REINDEX INDEX idx_users_email;
             REINDEX TABLE posts;

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -1,5 +1,5 @@
 use camino::Utf8Path;
-use diesel_guard::{Config, ConfigError, SafetyChecker};
+use diesel_guard::{Config, ConfigError, SafetyChecker, violation::Severity};
 use miette::Diagnostic as _;
 use std::fs;
 use tempfile::tempdir;
@@ -11,7 +11,11 @@ fn test_check_down_single_migration_dir() {
     fs::create_dir(&migration_dir).unwrap();
     fs::write(
         migration_dir.join("up.sql"),
-        "ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;",
+        r"
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+",
     )
     .unwrap();
     fs::write(
@@ -100,7 +104,11 @@ fn test_check_down_integration() {
     // Create up.sql with unsafe operation
     fs::write(
         migration_dir.join("up.sql"),
-        "ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;",
+        r"
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+",
     )
     .unwrap();
 
@@ -190,10 +198,14 @@ fn test_disable_checks_integration() {
     let migration_dir = temp_dir.path().join("2024_01_01_000000_test");
     fs::create_dir(&migration_dir).unwrap();
 
-    // SQL that would trigger AddColumnCheck
+    // SQL that would trigger AddColumnCheck without also triggering DdlTimeoutCheck.
     fs::write(
         migration_dir.join("up.sql"),
-        "ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;",
+        r"
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
+",
     )
     .unwrap();
 
@@ -224,6 +236,65 @@ fn test_disable_checks_integration() {
 }
 
 #[test]
+fn test_disable_checks_integration_for_statement_list_check() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let migration_dir = temp_dir.path().join("2024_01_01_000000_test");
+    fs::create_dir(&migration_dir).unwrap();
+
+    fs::write(
+        migration_dir.join("up.sql"),
+        "ALTER TYPE mood ADD VALUE 'sad';",
+    )
+    .unwrap();
+
+    let checker_default = SafetyChecker::with_config(Config {
+        enable_checks: vec!["DdlTimeoutCheck".to_string()],
+        ..Default::default()
+    });
+    let results_default = checker_default
+        .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
+        .unwrap();
+    assert_eq!(results_default.len(), 1);
+    assert_eq!(results_default[0].1.len(), 1);
+
+    let checker_disabled = SafetyChecker::with_config(Config {
+        disable_checks: vec!["DdlTimeoutCheck".to_string()],
+        ..Default::default()
+    });
+    let results_disabled = checker_disabled
+        .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
+        .unwrap();
+    assert_eq!(results_disabled.len(), 0);
+}
+
+#[test]
+fn test_warn_checks_integration_for_statement_list_check() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let migration_dir = temp_dir.path().join("2024_01_01_000000_test");
+    fs::create_dir(&migration_dir).unwrap();
+
+    fs::write(
+        migration_dir.join("up.sql"),
+        "ALTER TYPE mood ADD VALUE 'sad';",
+    )
+    .unwrap();
+
+    let checker = SafetyChecker::with_config(Config {
+        enable_checks: vec!["DdlTimeoutCheck".to_string()],
+        warn_checks: vec!["DdlTimeoutCheck".to_string()],
+        ..Default::default()
+    });
+    let results = checker
+        .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].1.len(), 1);
+    assert_eq!(results[0].1[0].1.check_name, "DdlTimeoutCheck");
+    assert_eq!(results[0].1[0].1.severity, Severity::Warning);
+}
+
+#[test]
 fn test_disable_checks_separates_serial_checks() {
     use std::collections::HashSet;
 
@@ -234,6 +305,8 @@ fn test_disable_checks_separates_serial_checks() {
     fs::write(
         migration_dir.join("up.sql"),
         r"
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
 CREATE TABLE IF NOT EXISTS events (id BIGSERIAL PRIMARY KEY);
 ALTER TABLE users ADD COLUMN IF NOT EXISTS id SERIAL;
 ",

--- a/tests/diesel_adapter_test.rs
+++ b/tests/diesel_adapter_test.rs
@@ -198,3 +198,33 @@ disable_checks = ["AddColumnCheck"]
         "ADD COLUMN without IF NOT EXISTS"
     );
 }
+
+#[test]
+fn test_diesel_metadata_can_disable_statement_list_check_for_one_migration() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let migration_dir = temp_dir.path().join("2024_01_01_000000_test");
+    fs::create_dir(&migration_dir).unwrap();
+    fs::write(
+        migration_dir.join("metadata.toml"),
+        r#"
+disable_checks = ["DdlTimeoutCheck"]
+"#,
+    )
+    .unwrap();
+    fs::write(
+        migration_dir.join("up.sql"),
+        "ALTER TABLE users ADD COLUMN admin BOOLEAN;",
+    )
+    .unwrap();
+
+    let config = Config {
+        framework: "diesel".to_string(),
+        enable_checks: vec!["DdlTimeoutCheck".to_string()],
+        ..Default::default()
+    };
+    let results = SafetyChecker::with_config(config)
+        .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
+        .unwrap();
+
+    assert_eq!(results.len(), 0);
+}

--- a/tests/diesel_adapter_test.rs
+++ b/tests/diesel_adapter_test.rs
@@ -96,6 +96,7 @@ fn test_concurrently_violations_include_diesel_transaction_hint() {
 
     let config = Config {
         framework: "diesel".to_string(),
+        disable_checks: vec!["DdlTimeoutCheck".to_string()],
         ..Default::default()
     };
     let results = SafetyChecker::with_config(config)

--- a/tests/fixtures/ddl_timeout_missing_statement_timeout_unsafe/up.sql
+++ b/tests/fixtures/ddl_timeout_missing_statement_timeout_unsafe/up.sql
@@ -1,0 +1,3 @@
+-- Unsafe: DDL runs with lock_timeout but no statement_timeout
+SET lock_timeout = '2s';
+ALTER TABLE users ADD COLUMN admin BOOLEAN;

--- a/tests/fixtures/ddl_timeout_safe/up.sql
+++ b/tests/fixtures/ddl_timeout_safe/up.sql
@@ -1,0 +1,4 @@
+-- Safe: DDL has lock_timeout and statement_timeout configured first
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+ALTER TABLE users ADD COLUMN admin BOOLEAN;

--- a/tests/fixtures/ddl_timeout_unsafe/up.sql
+++ b/tests/fixtures/ddl_timeout_unsafe/up.sql
@@ -1,0 +1,2 @@
+-- Unsafe: DDL runs without lock_timeout or statement_timeout
+ALTER TABLE users ADD COLUMN admin BOOLEAN;

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -13,6 +13,13 @@ const IDEMPOTENCY_CHECKS: &[&str] = &[
     "IdempotencyDropCheck",
     "IdempotencyIndexCheck",
 ];
+const AGGREGATE_DISABLED_CHECKS: &[&str] = &[
+    "DdlTimeoutCheck",
+    "IdempotencyAlterCheck",
+    "IdempotencyCreateCheck",
+    "IdempotencyDropCheck",
+    "IdempotencyIndexCheck",
+];
 
 /// Helper to get fixture path
 fn fixture_path(name: &str) -> String {
@@ -73,6 +80,7 @@ fn test_safe_fixtures_pass() {
             vec!["CreateTableWithoutPkCheck"],
         ),
         ("delete_with_where_safe", vec!["MutationWithoutWhereCheck"]),
+        ("ddl_timeout_safe", vec!["DdlTimeoutCheck"]),
         ("update_with_where_safe", vec!["MutationWithoutWhereCheck"]),
         (
             "domain_check_constraint_safe",
@@ -660,6 +668,41 @@ fn test_delete_without_where_detected() {
 }
 
 #[test]
+fn test_ddl_timeout_detected() {
+    let checker = checker_with_enabled_checks(&["DdlTimeoutCheck"]);
+    let path = fixture_path("ddl_timeout_unsafe");
+
+    let violations = checker.check_file(Utf8Path::new(&path)).unwrap();
+
+    assert_eq!(violations.len(), 1, "Expected 1 violation");
+    assert_eq!(
+        violations[0].1.operation,
+        "DDL without lock_timeout/statement_timeout"
+    );
+    assert!(
+        violations[0]
+            .1
+            .problem
+            .contains("lock_timeout and statement_timeout")
+    );
+}
+
+#[test]
+fn test_ddl_timeout_missing_statement_timeout_detected() {
+    let checker = checker_with_enabled_checks(&["DdlTimeoutCheck"]);
+    let path = fixture_path("ddl_timeout_missing_statement_timeout_unsafe");
+
+    let violations = checker.check_file(Utf8Path::new(&path)).unwrap();
+
+    assert_eq!(violations.len(), 1, "Expected 1 violation");
+    assert_eq!(
+        violations[0].1.operation,
+        "DDL without lock_timeout/statement_timeout"
+    );
+    assert!(violations[0].1.problem.contains("statement_timeout"));
+}
+
+#[test]
 fn test_update_without_where_detected() {
     let checker = checker_with_enabled_checks(&["MutationWithoutWhereCheck"]);
     let path = fixture_path("update_without_where_unsafe");
@@ -672,7 +715,7 @@ fn test_update_without_where_detected() {
 
 #[test]
 fn test_check_entire_fixtures_directory() {
-    let checker = checker_with_disabled_checks(IDEMPOTENCY_CHECKS);
+    let checker = checker_with_disabled_checks(AGGREGATE_DISABLED_CHECKS);
     let results = checker
         .check_directory(Utf8Path::new("tests/fixtures"))
         .unwrap();
@@ -894,7 +937,7 @@ fn test_sqlx_refresh_matview_concurrently_missing_directive_detected() {
 
 #[test]
 fn test_check_all_sqlx_fixtures() {
-    let checker = sqlx_checker_with_disabled_checks(IDEMPOTENCY_CHECKS, false);
+    let checker = sqlx_checker_with_disabled_checks(AGGREGATE_DISABLED_CHECKS, false);
 
     // Check each fixture directory individually and collect results
     let fixture_dirs = vec![
@@ -926,7 +969,7 @@ fn test_check_all_sqlx_fixtures() {
         }
     }
 
-    // Expected violations (with check_down = false and idempotency checks excluded):
+    // Expected violations (with check_down = false and broad aggregate checks excluded):
     // - sqlx_suffix_add_column_unsafe up.sql: 1
     // - sqlx_add_index_unsafe: 1
     // - sqlx_concurrently_missing_directive: 1
@@ -936,7 +979,8 @@ fn test_check_all_sqlx_fixtures() {
     // - sqlx_reindex_missing_directive: 1
     // - sqlx_refresh_matview_unsafe: 1
     // - sqlx_refresh_matview_missing_directive: 1
-    // Note: .down.sql is skipped here, and idempotency has dedicated fixture coverage.
+    // Note: .down.sql is skipped here. Idempotency and DDL timeout checks have
+    // dedicated fixture coverage.
     assert_eq!(
         files_with_violations, 9,
         "Expected 9 files with violations, got {files_with_violations}"

--- a/tests/safety_assured_test.rs
+++ b/tests/safety_assured_test.rs
@@ -25,6 +25,48 @@ ALTER TABLE posts DROP COLUMN body;
 }
 
 #[test]
+fn test_safety_assured_block_ignores_ddl_timeout_violations() {
+    let checker = SafetyChecker::with_config(Config {
+        enable_checks: vec!["DdlTimeoutCheck".to_string()],
+        ..Default::default()
+    });
+    let sql = r"
+-- safety-assured:start
+ALTER TABLE users ADD COLUMN admin BOOLEAN;
+-- safety-assured:end
+    ";
+
+    let violations = checker.check_sql(sql).unwrap();
+    assert_eq!(
+        violations.len(),
+        0,
+        "safety-assured block should ignore DDL timeout violations"
+    );
+}
+
+#[test]
+fn test_safety_assured_timeout_assignment_applies_after_block() {
+    let checker = SafetyChecker::with_config(Config {
+        enable_checks: vec!["DdlTimeoutCheck".to_string()],
+        ..Default::default()
+    });
+    let sql = r"
+-- safety-assured:start
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+-- safety-assured:end
+ALTER TABLE users ADD COLUMN admin BOOLEAN;
+    ";
+
+    let violations = checker.check_sql(sql).unwrap();
+    assert_eq!(
+        violations.len(),
+        0,
+        "timeout assignments inside safety-assured blocks should still affect later statements"
+    );
+}
+
+#[test]
 fn test_without_safety_assured_detects_violations() {
     let checker = SafetyChecker::with_config(Config {
         enable_checks: vec!["DropColumnCheck".to_string()],

--- a/tests/safety_assured_test.rs
+++ b/tests/safety_assured_test.rs
@@ -67,6 +67,33 @@ ALTER TABLE users ADD COLUMN admin BOOLEAN;
 }
 
 #[test]
+fn test_safety_assured_reset_clears_timeout_assignment_after_block() {
+    let checker = SafetyChecker::with_config(Config {
+        enable_checks: vec!["DdlTimeoutCheck".to_string()],
+        ..Default::default()
+    });
+    let sql = r"
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+-- safety-assured:start
+RESET ALL;
+-- safety-assured:end
+ALTER TABLE users ADD COLUMN admin BOOLEAN;
+    ";
+
+    let violations = checker.check_sql(sql).unwrap();
+    assert_eq!(
+        violations.len(),
+        1,
+        "RESET ALL inside safety-assured should still clear state for later DDL"
+    );
+    assert_eq!(
+        violations[0].1.operation,
+        "DDL without lock_timeout/statement_timeout"
+    );
+}
+
+#[test]
 fn test_without_safety_assured_detects_violations() {
     let checker = SafetyChecker::with_config(Config {
         enable_checks: vec!["DropColumnCheck".to_string()],
@@ -325,6 +352,21 @@ ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
         violations[0].1.operation,
         "ADD COLUMN without IF NOT EXISTS"
     );
+}
+
+#[test]
+fn test_per_migration_disable_directive_skips_statement_list_check() {
+    let checker = SafetyChecker::with_config(Config {
+        enable_checks: vec!["DdlTimeoutCheck".to_string()],
+        ..Default::default()
+    });
+    let sql = r"
+-- diesel-guard:disable DdlTimeoutCheck
+ALTER TABLE users ADD COLUMN admin BOOLEAN;
+    ";
+
+    let violations = checker.check_sql(sql).unwrap();
+    assert_eq!(violations.len(), 0);
 }
 
 #[test]

--- a/tests/sqlx_adapter_test.rs
+++ b/tests/sqlx_adapter_test.rs
@@ -16,6 +16,7 @@ fn test_concurrently_violations_include_sqlx_transaction_hint() {
 
     let config = Config {
         framework: "sqlx".to_string(),
+        disable_checks: vec!["DdlTimeoutCheck".to_string()],
         ..Default::default()
     };
     let results = SafetyChecker::with_config(config)


### PR DESCRIPTION
## What does this PR do?

Adds `DdlTimeoutCheck`, a new migration safety check that requires both `lock_timeout` and `statement_timeout` to be set to non-zero values before PostgreSQL DDL statements.

The check tracks timeout state across statement lists, handles timeout resets/defaults, supports `SET` and `SET LOCAL`, and reports missing timeout coverage before broad DDL operations such as table/schema/index changes, roles, privileges, publications, subscriptions, comments, security labels, and related object-definition statements.

This also documents the new check and adds regression coverage for configuration, Diesel metadata disables, per-migration disables, safety-assured reset behavior, zero timeout values, and representative DDL statement families.

Closes #97

## Tests

- `cargo test ddl_timeout --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `just ci`

## Checklist

- [x] Relevant issue assigned under the `Development` section
- [x] Docs updated (`docs/src/checks/<check>.md` + `docs/src/SUMMARY.md`)
- [x] One check per PR
- [x] No unrelated changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a **DDL Timeouts** check to ensure `lock_timeout` and `statement_timeout` are set before DDL runs, covering `SET LOCAL` and timeout clearing behaviors.
  * Supports configuration-driven control, including per-migration metadata and correct warning/disabled outcomes.

* **Documentation**
  * Added and linked the **DDL Timeouts** documentation to the checks overview and configuration tables.

* **Tests**
  * Expanded fixtures and test coverage for safe/unsafe DDL timeout scenarios and `safety-assured` block behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->