### PR TITLE
Invalid start_after can silently skip all migrations

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -165,9 +165,6 @@ impl Config {
             }
         }
 
-        // Timestamp validation is framework-specific and done by adapters
-        // during migration file collection
-
         if !self.enable_checks.is_empty() && !self.disable_checks.is_empty() {
             return Err(ConfigError::ConflictingCheckConfig);
         }

--- a/src/safety_checker.rs
+++ b/src/safety_checker.rs
@@ -187,6 +187,12 @@ impl SafetyChecker {
     pub fn check_directory(&self, dir: &Utf8Path) -> Result<Vec<(String, ViolationList)>> {
         let adapter = self.adapter()?;
 
+        if let Some(start_after) = self.config.start_after.as_deref() {
+            adapter
+                .validate_timestamp(start_after)
+                .map_err(|e| crate::config::ConfigError::InvalidTimestampFormat(e.to_string()))?;
+        }
+
         let migration_files = adapter
             .collect_migration_files(
                 dir,

--- a/tests/diesel_adapter_test.rs
+++ b/tests/diesel_adapter_test.rs
@@ -1,5 +1,6 @@
 use camino::Utf8Path;
-use diesel_guard::{Config, SafetyChecker};
+use diesel_guard::error::DieselGuardError;
+use diesel_guard::{Config, ConfigError, SafetyChecker};
 use std::fs;
 use tempfile::tempdir;
 
@@ -33,6 +34,36 @@ fn test_diesel_loose_sql_and_directory_migrations_coexist() {
         2,
         "Both directory and loose SQL migrations should be discovered, got: {:?}",
         results.iter().map(|(p, _)| p).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_invalid_start_after_returns_error() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let mig = temp_dir.path().join("2024_01_01_000000_create_users");
+    fs::create_dir(&mig).unwrap();
+    fs::write(mig.join("up.sql"), "SELECT 1;").unwrap();
+
+    let config = Config {
+        framework: "diesel".to_string(),
+        start_after: Some("not-a-timestamp".to_string()),
+        ..Default::default()
+    };
+    let checker = SafetyChecker::with_config(config);
+    let err = checker
+        .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            DieselGuardError::ConfigError(ConfigError::InvalidTimestampFormat(_))
+        ),
+        "Expected InvalidTimestampFormat, got: {err:?}"
+    );
+    assert_eq!(
+        err.to_string(),
+        "Invalid timestamp format: Invalid Diesel timestamp format: not-a-timestamp. Expected: YYYYMMDDHHMMSS, YYYY_MM_DD_HHMMSS, or YYYY-MM-DD-HHMMSS"
     );
 }
 

--- a/tests/sqlx_adapter_test.rs
+++ b/tests/sqlx_adapter_test.rs
@@ -1,7 +1,37 @@
 use camino::Utf8Path;
-use diesel_guard::{Config, SafetyChecker};
+use diesel_guard::error::DieselGuardError;
+use diesel_guard::{Config, ConfigError, SafetyChecker};
 use std::fs;
 use tempfile::tempdir;
+
+#[test]
+fn test_invalid_start_after_returns_error() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let mig = temp_dir.path().join("20240101000000_create_users.sql");
+    fs::write(&mig, "SELECT 1;").unwrap();
+
+    let config = Config {
+        framework: "sqlx".to_string(),
+        start_after: Some("not-a-timestamp".to_string()),
+        ..Default::default()
+    };
+    let checker = SafetyChecker::with_config(config);
+    let err = checker
+        .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            DieselGuardError::ConfigError(ConfigError::InvalidTimestampFormat(_))
+        ),
+        "Expected InvalidTimestampFormat, got: {err:?}"
+    );
+    assert_eq!(
+        err.to_string(),
+        "Invalid timestamp format: Invalid SQLx version format: not-a-timestamp. Expected: one or more digits"
+    );
+}
 
 #[test]
 fn test_concurrently_violations_include_sqlx_transaction_hint() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of the `start_after` configuration parameter to catch invalid timestamp formats with clear error messages before processing migration files

* **Tests**
  * Added comprehensive tests to verify proper error handling for invalid `start_after` timestamp values across different adapters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->