### PR TITLE
A typo in enable_checks can disable the linter

### DIFF
--- a/src/adapters/diesel.rs
+++ b/src/adapters/diesel.rs
@@ -49,7 +49,7 @@ impl MigrationAdapter for DieselAdapter {
             return Ok(self.process_migration_directory(dir, None, check_down));
         }
 
-        let entries = collect_and_sort_entries(dir);
+        let entries = collect_and_sort_entries(dir)?;
         let mut files = Vec::new();
 
         for entry in entries {

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -161,19 +161,13 @@ pub(crate) fn is_single_migration_dir(dir: &Utf8Path) -> bool {
 /// Collect and sort directory entries from a directory.
 ///
 /// Returns entries sorted by path, with errors filtered out.
-pub(crate) fn collect_and_sort_entries(dir: &Utf8Path) -> Vec<DirEntry> {
+pub(crate) fn collect_and_sort_entries(dir: &Utf8Path) -> Result<Vec<DirEntry>> {
     let mut entries = Vec::new();
     for result in WalkDir::new(dir).max_depth(1).min_depth(1) {
-        match result {
-            Ok(entry) => entries.push(entry),
-            Err(e) => {
-                eprintln!("Warning: Failed to read entry in {dir}: {e}");
-            }
-        }
+        entries.push(result?);
     }
-
     entries.sort_by(|a, b| a.path().cmp(b.path()));
-    entries
+    Ok(entries)
 }
 
 #[cfg(test)]

--- a/src/adapters/sqlx.rs
+++ b/src/adapters/sqlx.rs
@@ -33,7 +33,7 @@ impl MigrationAdapter for SqlxAdapter {
         start_after: Option<&str>,
         check_down: bool,
     ) -> Result<Vec<MigrationFile>> {
-        let entries = collect_and_sort_entries(dir);
+        let entries = collect_and_sort_entries(dir)?;
         let mut files = Vec::new();
 
         for entry in entries {

--- a/src/checks/add_index.rs
+++ b/src/checks/add_index.rs
@@ -223,9 +223,9 @@ mod tests {
             },
         );
         assert_eq!(violations.len(), 1);
-        assert!(
-            violations[0].safe_alternative.contains("-- no-transaction"),
-            "Expected SQLx safe alternative message"
+        assert_eq!(
+            violations[0].safe_alternative,
+            "Add `-- no-transaction` as the first line of the migration file."
         );
     }
 
@@ -242,9 +242,9 @@ mod tests {
             },
         );
         assert_eq!(violations.len(), 1);
-        assert!(
-            violations[0].safe_alternative.contains("metadata.toml"),
-            "Expected Diesel safe alternative message"
+        assert_eq!(
+            violations[0].safe_alternative,
+            "Create `metadata.toml` in the migration directory with `run_in_transaction = false`."
         );
     }
 

--- a/src/checks/idempotency_create.rs
+++ b/src/checks/idempotency_create.rs
@@ -64,11 +64,13 @@ mod tests {
         );
 
         assert_eq!(violations.len(), 1);
-        assert!(violations[0].problem.contains("<table_name>"));
-        assert!(
-            violations[0]
-                .safe_alternative
-                .contains("CREATE TABLE IF NOT EXISTS <table_name> (...);")
+        assert_eq!(
+            violations[0].problem,
+            "CREATE TABLE for '<table_name>' is not idempotent. If this migration is retried after a partial failure, it can error because the table already exists."
+        );
+        assert_eq!(
+            violations[0].safe_alternative,
+            "Use IF NOT EXISTS to make retries safe:\n   CREATE TABLE IF NOT EXISTS <table_name> (...);"
         );
     }
 

--- a/src/checks/idempotency_index.rs
+++ b/src/checks/idempotency_index.rs
@@ -87,11 +87,13 @@ mod tests {
         );
 
         assert_eq!(violations.len(), 1);
-        assert!(violations[0].problem.contains("<unnamed>"));
-        assert!(
-            violations[0]
-                .safe_alternative
-                .contains("CREATE INDEX IF NOT EXISTS <index_name> ON <table_name> (...);")
+        assert_eq!(
+            violations[0].problem,
+            "CREATE INDEX '<unnamed>' on table '<table_name>' is not idempotent. If this migration is retried after a partial failure, it can error because the index already exists."
+        );
+        assert_eq!(
+            violations[0].safe_alternative,
+            "Use IF NOT EXISTS to make retries safe:\n   CREATE INDEX IF NOT EXISTS <index_name> ON <table_name> (...);"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,19 @@
+//! Safety linter for Diesel and SQLx migration files.
+//!
+//! `diesel-guard` inspects SQL migration files and reports statements that are
+//! unsafe to run on a live PostgreSQL database (e.g. adding a NOT NULL column
+//! without a default, dropping an index non-concurrently, locking a table).
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use diesel_guard::SafetyChecker;
+//! use camino::Utf8Path;
+//!
+//! let checker = SafetyChecker::default();
+//! let violations = checker.check_path(Utf8Path::new("migrations/")).unwrap();
+//! ```
+
 pub mod adapters;
 pub mod ast_dump;
 pub mod checks;

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ EXAMPLES:
 
 fn run_check(path: &camino::Utf8Path, format: Format) -> Result<()> {
     let config = Config::load().map_err(|e| miette::miette!(e))?;
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).map_err(|e| miette::miette!(e))?;
     let results = checker.check_path(path)?;
     let total_errors: usize = results
         .iter()
@@ -177,7 +177,8 @@ fn load_all_checks() -> Result<(Config, SafetyChecker)> {
         disable_checks: vec![],
         enable_checks: vec![],
         ..config.clone()
-    });
+    })
+    .map_err(|e| miette::miette!(e))?;
     Ok((config, checker))
 }
 

--- a/src/safety_checker.rs
+++ b/src/safety_checker.rs
@@ -16,18 +16,14 @@ pub struct SafetyChecker {
 }
 
 impl SafetyChecker {
-    /// Create with configuration loaded from diesel-guard.toml
-    /// Falls back to defaults if config file doesn't exist or has errors
-    pub fn new() -> Self {
-        let config = Config::load().unwrap_or_else(|e| {
-            eprintln!("Warning: Failed to load config: {e}. Using defaults.");
-            Config::default()
-        });
-        Self::with_config(config)
-    }
-
     /// Create with specific configuration (useful for testing)
-    pub fn with_config(config: Config) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::config::ConfigError::InvalidCheckName`] if any name in `enable_checks`,
+    /// `disable_checks`, or `warn_checks` is not a known check name (built-in or
+    /// custom script stem from `custom_checks_dir`).
+    pub fn with_config(config: Config) -> std::result::Result<Self, crate::config::ConfigError> {
         let mut registry = Registry::with_config(&config);
 
         if let Some(ref dir) = config.custom_checks_dir {
@@ -43,10 +39,7 @@ impl SafetyChecker {
             }
         }
 
-        // Warn about unknown check names.
-        // We check against all built-in names (not just enabled ones) and all
-        // custom script stems so that disabling a valid check doesn't trigger
-        // a spurious warning.
+        // Validate check names against all built-in names and custom script stems.
         let builtin_names = Registry::builtin_check_names();
         let custom_names: Vec<String> = config
             .custom_checks_dir
@@ -78,25 +71,26 @@ impl SafetyChecker {
             .chain(custom_names.iter().cloned())
             .collect::<Vec<_>>();
 
-        let warn_unknown = |names: &[String], field: &str| {
+        let validate_names = |names: &[String]| {
             for name in names {
                 if !known_check_names.iter().any(|known| known == name) {
-                    eprintln!(
-                        "Warning: Unknown check name '{name}' in {field}. Run --list-checks to see available checks."
-                    );
+                    return Err(crate::config::ConfigError::InvalidCheckName {
+                        invalid_name: name.clone(),
+                    });
                 }
             }
+            Ok(())
         };
 
-        warn_unknown(&config.disable_checks, "disable_checks");
-        warn_unknown(&config.enable_checks, "enable_checks");
-        warn_unknown(&config.warn_checks, "warn_checks");
+        validate_names(&config.disable_checks)?;
+        validate_names(&config.enable_checks)?;
+        validate_names(&config.warn_checks)?;
 
-        Self {
+        Ok(Self {
             registry,
             config,
             known_check_names,
-        }
+        })
     }
 
     /// Expose the registry for introspection (e.g. list-checks, explain).
@@ -267,7 +261,7 @@ impl SafetyChecker {
 
 impl Default for SafetyChecker {
     fn default() -> Self {
-        Self::new()
+        Self::with_config(Config::default()).unwrap()
     }
 }
 
@@ -283,7 +277,8 @@ mod tests {
         let checker = SafetyChecker::with_config(Config {
             enable_checks: vec!["AddColumnCheck".to_string()],
             ..Default::default()
-        });
+        })
+        .unwrap();
         let sql = "ALTER TABLE users ADD COLUMN email VARCHAR(255);";
         let violations = checker.check_sql(sql).unwrap();
         assert_eq!(violations.len(), 0);
@@ -294,7 +289,8 @@ mod tests {
         let checker = SafetyChecker::with_config(Config {
             enable_checks: vec!["AddColumnCheck".to_string()],
             ..Default::default()
-        });
+        })
+        .unwrap();
         let sql = "ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;";
         let violations = checker.check_sql(sql).unwrap();
         assert_eq!(violations.len(), 1);
@@ -306,7 +302,7 @@ mod tests {
             disable_checks: vec!["AddColumnCheck".to_string()],
             ..Default::default()
         };
-        let checker = SafetyChecker::with_config(config);
+        let checker = SafetyChecker::with_config(config).unwrap();
 
         let sql = "ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;";
         let violations = checker.check_sql(sql).unwrap();
@@ -320,7 +316,7 @@ mod tests {
 
     #[test]
     fn test_reindex_without_concurrently_detected() {
-        let checker = SafetyChecker::new();
+        let checker = SafetyChecker::default();
         let sql = "REINDEX INDEX idx_users_email;";
         let violations = checker.check_sql(sql).unwrap();
         assert_eq!(violations.len(), 1);
@@ -329,7 +325,7 @@ mod tests {
 
     #[test]
     fn test_reindex_table_without_concurrently_detected() {
-        let checker = SafetyChecker::new();
+        let checker = SafetyChecker::default();
         let sql = "REINDEX TABLE users;";
         let violations = checker.check_sql(sql).unwrap();
         assert_eq!(violations.len(), 1);
@@ -340,7 +336,7 @@ mod tests {
     fn test_reindex_concurrently_in_transaction_detected() {
         // check_sql uses MigrationContext::default() (run_in_transaction=true),
         // so REINDEX CONCURRENTLY is flagged as requiring no-transaction context.
-        let checker = SafetyChecker::new();
+        let checker = SafetyChecker::default();
         let sql = "REINDEX INDEX CONCURRENTLY idx_users_email;";
         let violations = checker.check_sql(sql).unwrap();
         assert_eq!(violations.len(), 1);
@@ -356,7 +352,7 @@ mod tests {
             disable_checks: vec!["ReindexCheck".to_string()],
             ..Default::default()
         };
-        let checker = SafetyChecker::with_config(config);
+        let checker = SafetyChecker::with_config(config).unwrap();
 
         let sql = "REINDEX INDEX idx_users_email;";
         let violations = checker.check_sql(sql).unwrap();
@@ -365,7 +361,7 @@ mod tests {
 
     #[test]
     fn test_multiple_reindex_violations() {
-        let checker = SafetyChecker::new();
+        let checker = SafetyChecker::default();
         let sql = r"
             REINDEX INDEX idx_users_email;
             REINDEX TABLE posts;
@@ -380,7 +376,7 @@ mod tests {
             framework: "unknown".to_string(),
             ..Default::default()
         };
-        let checker = SafetyChecker::with_config(config);
+        let checker = SafetyChecker::with_config(config).unwrap();
         let result = checker.check_directory(camino::Utf8Path::new("."));
         assert_eq!(
             result.unwrap_err().to_string(),
@@ -393,7 +389,8 @@ mod tests {
         let checker = SafetyChecker::with_config(Config {
             enable_checks: vec!["AddColumnCheck".to_string()],
             ..Default::default()
-        });
+        })
+        .unwrap();
         let input_data = "ALTER TABLE users ADD COLUMN foo TEXT;";
         let violations = checker
             .check_buffer(&mut BufReader::new(Cursor::new(input_data)))
@@ -406,7 +403,8 @@ mod tests {
         let checker = SafetyChecker::with_config(Config {
             enable_checks: vec!["AddColumnCheck".to_string()],
             ..Default::default()
-        });
+        })
+        .unwrap();
         let input_data = "ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;";
         let violations = checker
             .check_buffer(&mut BufReader::new(Cursor::new(input_data)))
@@ -423,7 +421,7 @@ mod tests {
             ..Default::default()
         };
         // Should not panic; .txt file is silently ignored
-        let checker = SafetyChecker::with_config(config);
+        let checker = SafetyChecker::with_config(config).unwrap();
         let violations = checker
             .check_sql("ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;")
             .unwrap();
@@ -436,18 +434,15 @@ mod tests {
     }
 
     #[test]
-    fn test_unknown_check_name_in_enable_checks_warns() {
-        let config = Config {
+    fn test_unknown_check_name_in_enable_checks_errors() {
+        let result = SafetyChecker::with_config(Config {
             enable_checks: vec!["NonExistentCheck".to_string()],
             ..Default::default()
-        };
-        // Should not panic; warning is printed to stderr
-        let checker = SafetyChecker::with_config(config);
-        let violations = checker
-            .check_sql("ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;")
-            .unwrap();
-        // NonExistentCheck is unknown so nothing runs — zero violations
-        assert_eq!(violations.len(), 0);
+        });
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            "Invalid check name: NonExistentCheck"
+        );
     }
 
     #[test]
@@ -462,7 +457,7 @@ mod tests {
         let sql = "CREATE TABLE a ();\nCREATE TABLE b ();\nCREATE TABLE @bad;";
         fs::write(&file_path, sql).unwrap();
 
-        let checker = SafetyChecker::new();
+        let checker = SafetyChecker::default();
         let path = camino::Utf8Path::from_path(&file_path).unwrap();
         let err = checker.check_file(path).unwrap_err();
 
@@ -481,18 +476,32 @@ mod tests {
     }
 
     #[test]
-    fn test_unknown_check_name_in_disable_checks_warns() {
-        let config = Config {
+    fn test_unknown_check_name_in_disable_checks_errors() {
+        let result = SafetyChecker::with_config(Config {
             disable_checks: vec!["NonExistentCheck".to_string()],
             ..Default::default()
-        };
-        // Should not panic; warning is printed to stderr
-        let _checker = SafetyChecker::with_config(config);
+        });
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            "Invalid check name: NonExistentCheck"
+        );
+    }
+
+    #[test]
+    fn test_unknown_check_name_in_warn_checks_errors() {
+        let result = SafetyChecker::with_config(Config {
+            warn_checks: vec!["NonExistentCheck".to_string()],
+            ..Default::default()
+        });
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            "Invalid check name: NonExistentCheck"
+        );
     }
 
     #[test]
     fn test_buffer_empty_string() {
-        let checker: SafetyChecker = SafetyChecker::new();
+        let checker = SafetyChecker::default();
         let input_data = "";
         let violations = checker
             .check_buffer(&mut BufReader::new(Cursor::new(input_data)))
@@ -502,7 +511,7 @@ mod tests {
 
     #[test]
     fn test_buffer_input_multiple_lines() {
-        let checker: SafetyChecker = SafetyChecker::new();
+        let checker = SafetyChecker::default();
         let input_data = r"
             REINDEX INDEX idx_users_email;
             REINDEX TABLE posts;
@@ -534,7 +543,7 @@ mod tests {
             enable_checks: vec!["AddIndexCheck".to_string()],
             ..Default::default()
         };
-        let checker = SafetyChecker::with_config(config);
+        let checker = SafetyChecker::with_config(config).unwrap();
         let dir_path =
             camino::Utf8Path::from_path(temp_dir.path()).expect("path should be valid UTF-8");
 
@@ -573,7 +582,7 @@ mod tests {
             enable_checks: vec!["AddIndexCheck".to_string()],
             ..Default::default()
         };
-        let checker = SafetyChecker::with_config(config);
+        let checker = SafetyChecker::with_config(config).unwrap();
         let dir_path =
             camino::Utf8Path::from_path(temp_dir.path()).expect("path should be valid UTF-8");
 
@@ -601,7 +610,8 @@ mod tests {
             framework: "sqlx".to_string(),
             enable_checks: vec!["AddIndexCheck".to_string()],
             ..Default::default()
-        });
+        })
+        .unwrap();
         let dir_path =
             camino::Utf8Path::from_path(temp_dir.path()).expect("path should be valid UTF-8");
 
@@ -632,7 +642,8 @@ mod tests {
             framework: "sqlx".to_string(),
             enable_checks: vec!["AddIndexCheck".to_string()],
             ..Default::default()
-        });
+        })
+        .unwrap();
         let dir_path =
             camino::Utf8Path::from_path(temp_dir.path()).expect("path should be valid UTF-8");
 
@@ -651,6 +662,7 @@ mod tests {
             enable_checks: vec!["DropColumnCheck".to_string()],
             ..Default::default()
         })
+        .unwrap()
     }
 
     fn violation_lines(checker: &SafetyChecker, sql: &str) -> Vec<usize> {
@@ -709,7 +721,7 @@ mod tests {
 
     #[test]
     fn test_registry_returns_inner_registry() {
-        let checker = SafetyChecker::new();
+        let checker = SafetyChecker::default();
         assert_eq!(
             checker.registry().active_check_names().len(),
             Registry::builtin_check_names().len()
@@ -730,7 +742,8 @@ mod tests {
         let checker = SafetyChecker::with_config(Config {
             enable_checks: vec!["DropTableCheck".to_string()],
             ..Config::default()
-        });
+        })
+        .unwrap();
         let path = Utf8Path::from_path(&file).unwrap();
         let results = checker.check_path(path).unwrap();
         assert!(results.is_empty(), "Safe SQL should produce no violations");
@@ -744,7 +757,8 @@ mod tests {
         let checker = SafetyChecker::with_config(Config {
             enable_checks: vec!["DropTableCheck".to_string()],
             ..Config::default()
-        });
+        })
+        .unwrap();
         let path = Utf8Path::from_path(&file).unwrap();
         let results = checker.check_path(path).unwrap();
         assert_eq!(results.len(), 1, "Expected one file with violations");
@@ -754,7 +768,7 @@ mod tests {
 
     #[test]
     fn test_check_sql_warns_on_duplicate_migration_disabled_checks() {
-        let checker = SafetyChecker::with_config(Config::default());
+        let checker = SafetyChecker::default();
         // Duplicate name in disable directive — warn_unknown_migration_disabled_checks deduplicates.
         let sql = "-- diesel-guard:disable AddColumnCheck,AddColumnCheck\nALTER TABLE t ADD COLUMN x TEXT;";
         // Should not panic or error; just runs (warning goes to stderr).
@@ -763,7 +777,7 @@ mod tests {
 
     #[test]
     fn test_check_sql_warns_on_unknown_migration_disabled_check() {
-        let checker = SafetyChecker::with_config(Config::default());
+        let checker = SafetyChecker::default();
         // FakeCheck is not a known check name — triggers the eprintln warning path.
         let sql =
             "-- diesel-guard:disable FakeCheckThatDoesNotExist\nALTER TABLE t ADD COLUMN x TEXT;";

--- a/src/scripting.rs
+++ b/src/scripting.rs
@@ -643,7 +643,7 @@ mod tests {
         let (checks, errors) = load_custom_checks(dir_path, &config);
         assert_eq!(checks.len(), 0);
         assert_eq!(errors.len(), 1);
-        assert!(errors[0].message.contains("Failed to read directory"));
+        assert!(errors[0].message.starts_with("Failed to read directory:"));
     }
 
     #[test]
@@ -695,10 +695,9 @@ mod tests {
         );
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].operation, "CONCURRENTLY in transaction");
-        assert!(
-            violations[0]
-                .safe_alternative
-                .contains("diesel:no-transaction")
+        assert_eq!(
+            violations[0].safe_alternative,
+            "Add -- diesel:no-transaction to the migration file."
         );
     }
 
@@ -717,7 +716,7 @@ mod tests {
 
         assert_eq!(checks.len(), 0);
         assert_eq!(errors.len(), 1);
-        assert!(errors[0].message.contains("Failed to read"));
+        assert!(errors[0].message.starts_with("Failed to read:"));
     }
 
     #[test]
@@ -746,10 +745,9 @@ mod tests {
         );
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].operation, "SCRIPT ERROR: test_check");
-        assert!(
-            violations[0].problem.contains("'problem' must be a string"),
-            "got: {}",
-            violations[0].problem
+        assert_eq!(
+            violations[0].problem,
+            "Custom check returned an invalid map: 'problem' must be a string (got i64)"
         );
     }
 
@@ -761,12 +759,9 @@ mod tests {
         );
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].operation, "SCRIPT ERROR: test_check");
-        assert!(
-            violations[0]
-                .problem
-                .contains("'safe_alternative' must be a string"),
-            "got: {}",
-            violations[0].problem
+        assert_eq!(
+            violations[0].problem,
+            "Custom check returned an invalid map: 'safe_alternative' must be a string (got bool)"
         );
     }
 

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -23,7 +23,7 @@ fn test_check_down_single_migration_dir() {
 
     // Point check_path at the single migration directory (the CI use case)
     let config = Config::default(); // check_down = false
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_path(Utf8Path::from_path(&migration_dir).unwrap())
         .unwrap();
@@ -114,7 +114,7 @@ fn test_check_down_integration() {
 
     // Test with check_down = false (default)
     let config_default = Config::default();
-    let checker_default = SafetyChecker::with_config(config_default);
+    let checker_default = SafetyChecker::with_config(config_default).unwrap();
     let results_default = checker_default
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -126,7 +126,7 @@ fn test_check_down_integration() {
         check_down: true,
         ..Default::default()
     };
-    let checker_with_down = SafetyChecker::with_config(config_with_down);
+    let checker_with_down = SafetyChecker::with_config(config_with_down).unwrap();
     let results_with_down = checker_with_down
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -175,7 +175,7 @@ fn test_start_after_integration() {
         start_after: Some("2024_01_01_000000".to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -200,7 +200,7 @@ fn test_disable_checks_integration() {
 
     // Without disabling - AddColumnCheck and IdempotencyAlterCheck both detect the statement
     let config_default = Config::default();
-    let checker_default = SafetyChecker::with_config(config_default);
+    let checker_default = SafetyChecker::with_config(config_default).unwrap();
     let results_default = checker_default
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -212,7 +212,7 @@ fn test_disable_checks_integration() {
         disable_checks: vec!["AddColumnCheck".to_string()],
         ..Default::default()
     };
-    let checker_disabled = SafetyChecker::with_config(config_disabled);
+    let checker_disabled = SafetyChecker::with_config(config_disabled).unwrap();
     let results_disabled = checker_disabled
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -241,7 +241,7 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS id SERIAL;
     )
     .unwrap();
 
-    let checker_default = SafetyChecker::with_config(Config::default());
+    let checker_default = SafetyChecker::default();
     let results_default = checker_default
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -259,7 +259,8 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS id SERIAL;
     let checker_add_disabled = SafetyChecker::with_config(Config {
         disable_checks: vec!["AddSerialColumnCheck".to_string()],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let results_add_disabled = checker_add_disabled
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -273,7 +274,8 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS id SERIAL;
     let checker_create_disabled = SafetyChecker::with_config(Config {
         disable_checks: vec!["CreateTableSerialCheck".to_string()],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let results_create_disabled = checker_create_disabled
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -324,7 +326,7 @@ fn test_combined_config_features() {
         ..Default::default()
     };
 
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -353,7 +355,7 @@ fn test_standalone_sql_files_always_checked() {
         ..Default::default()
     };
 
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -378,7 +380,7 @@ fn test_check_down_with_missing_down_sql() {
         ..Default::default()
     };
 
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -417,7 +419,7 @@ fn test_multiple_migrations_with_start_after() {
         ..Default::default()
     };
 
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -453,7 +455,7 @@ fn test_migrations_checked_in_alphanumeric_order() {
         .unwrap();
     }
 
-    let checker = SafetyChecker::new();
+    let checker = SafetyChecker::default();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -498,7 +500,7 @@ fn test_standalone_sql_with_timestamp_respects_start_after() {
         ..Default::default()
     };
 
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -523,7 +525,7 @@ fn test_standalone_sql_with_timestamp_after_start_after() {
         ..Default::default()
     };
 
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -549,7 +551,7 @@ fn test_standalone_sql_without_timestamp_always_checked() {
         ..Default::default()
     };
 
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -577,7 +579,7 @@ fn test_enable_checks_integration() {
         enable_checks: vec!["AddColumnCheck".to_string()],
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -606,7 +608,7 @@ fn test_enable_checks_suppresses_all_when_unmatched() {
         enable_checks: vec!["AddIndexCheck".to_string()],
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -657,7 +659,8 @@ fn test_diesel_concurrently_without_metadata_warns() {
     let checker = SafetyChecker::with_config(Config {
         enable_checks: vec!["AddIndexCheck".to_string()],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();

--- a/tests/cross_feature_test.rs
+++ b/tests/cross_feature_test.rs
@@ -49,7 +49,7 @@ DROP TABLE unprotected_table;
         custom_checks_dir: Some(checks_dir.path().to_str().unwrap().to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(migrations_dir.path()).unwrap())
         .unwrap();
@@ -113,7 +113,7 @@ fn test_disable_builtin_and_custom_checks_simultaneously() {
         disable_checks: vec!["DropColumnCheck".to_string(), "my_check".to_string()],
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
 
     // SQL that triggers DropTableCheck, DropColumnCheck, and my_check
     let violations = checker
@@ -172,7 +172,7 @@ ALTER TABLE users DROP COLUMN phone;
         enable_checks: vec!["DropColumnCheck".to_string()],
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();

--- a/tests/custom_checks_test.rs
+++ b/tests/custom_checks_test.rs
@@ -28,7 +28,7 @@ fn test_custom_check_fires_alongside_builtin() {
         custom_checks_dir: Some(dir.path().to_str().unwrap().to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
 
     // This SQL triggers both the built-in AddIndexCheck and our custom check
     let violations = checker
@@ -85,7 +85,7 @@ fn test_disable_checks_works_for_custom_check() {
         disable_checks: vec!["my_custom".to_string()],
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
 
     let violations = checker
         .check_sql("CREATE INDEX idx ON users(email);")
@@ -122,7 +122,7 @@ fn test_safety_assured_blocks_skip_custom_checks() {
         custom_checks_dir: Some(dir.path().to_str().unwrap().to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
 
     let sql = r"
 -- safety-assured:start
@@ -172,7 +172,7 @@ fn test_custom_check_in_migration_directory() {
         custom_checks_dir: Some(checks_dir.path().to_str().unwrap().to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
 
     let results = checker
         .check_path(Utf8Path::from_path(migrations_dir.path()).unwrap())
@@ -195,7 +195,7 @@ fn test_nonexistent_custom_checks_dir_is_ignored() {
     };
 
     // Should not panic or error — just ignored
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let violations = checker.check_sql("SELECT 1;").unwrap();
     assert!(violations.is_empty());
 }
@@ -250,9 +250,9 @@ fn test_registry_check_names_includes_custom_checks() {
 }
 
 #[test]
-fn test_unknown_check_name_warning_not_emitted_for_custom_check() {
+fn test_unknown_check_name_not_raised_for_custom_check() {
     // When a disable_checks entry matches a custom check script name,
-    // SafetyChecker::with_config() should NOT warn about it.
+    // SafetyChecker::with_config() should NOT error about it.
     // The validation checks .rhai file stems on disk, not just what was
     // loaded into the registry (disabled checks are skipped during loading).
     let dir = tempdir().expect("Failed to create temp dir");
@@ -277,9 +277,8 @@ fn test_unknown_check_name_warning_not_emitted_for_custom_check() {
         ..Default::default()
     };
 
-    // Building SafetyChecker should not panic or error.
-    // The "my_custom" name matches a .rhai file stem so no warning is expected.
-    let checker = SafetyChecker::with_config(config);
+    // Building SafetyChecker should not error: "my_custom" matches a .rhai file stem.
+    let checker = SafetyChecker::with_config(config).unwrap();
 
     // Verify the custom check is actually disabled
     let violations = checker
@@ -294,11 +293,7 @@ fn test_unknown_check_name_warning_not_emitted_for_custom_check() {
 }
 
 #[test]
-fn test_unknown_check_name_detected_after_custom_checks_loaded() {
-    // A truly unknown name (typo) should not match any built-in name or
-    // custom .rhai file stem. SafetyChecker::with_config() will warn about it
-    // on stderr. We verify indirectly: the name doesn't appear in either the
-    // built-in list or the custom check file stems.
+fn test_unknown_check_name_errors_after_custom_checks_loaded() {
     let dir = tempdir().expect("Failed to create temp dir");
 
     fs::write(
@@ -315,42 +310,15 @@ fn test_unknown_check_name_detected_after_custom_checks_loaded() {
     )
     .unwrap();
 
-    let bogus = "TotallyBogusCheckName";
-
-    // Verify it doesn't match any built-in name
-    assert!(
-        !diesel_guard::checks::Registry::builtin_check_names().contains(&bogus),
-        "Typo should not match any built-in check name"
-    );
-
-    // Verify it doesn't match any custom check file stem
-    let rhai_stems: Vec<String> = fs::read_dir(dir.path())
-        .unwrap()
-        .filter_map(|e| {
-            let path = e.ok()?.path();
-            if path.extension().and_then(|e| e.to_str()) == Some("rhai") {
-                path.file_stem()
-                    .and_then(|s| s.to_str())
-                    .map(std::string::ToString::to_string)
-            } else {
-                None
-            }
-        })
-        .collect();
-    assert!(
-        !rhai_stems.contains(&bogus.to_string()),
-        "Typo should not match any custom check file stem"
-    );
-
-    // Building SafetyChecker should still succeed (warning on stderr, not an error)
-    let config = Config {
+    let result = SafetyChecker::with_config(Config {
         custom_checks_dir: Some(dir.path().to_str().unwrap().to_string()),
-        disable_checks: vec![bogus.to_string()],
+        disable_checks: vec!["TotallyBogusCheckName".to_string()],
         ..Default::default()
-    };
-    let checker = SafetyChecker::with_config(config);
-    let violations = checker.check_sql("SELECT 1;").unwrap();
-    assert!(violations.is_empty());
+    });
+    assert_eq!(
+        result.err().unwrap().to_string(),
+        "Invalid check name: TotallyBogusCheckName"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -390,7 +358,10 @@ fn check_with_examples(sql: &str) -> ViolationList {
         ],
         ..Default::default()
     };
-    SafetyChecker::with_config(config).check_sql(sql).unwrap()
+    SafetyChecker::with_config(config)
+        .unwrap()
+        .check_sql(sql)
+        .unwrap()
 }
 
 fn has_violation_containing(violations: &ViolationList, substring: &str) -> bool {
@@ -549,7 +520,7 @@ fn test_custom_check_returning_array_of_violations() {
         custom_checks_dir: Some(dir.path().to_str().unwrap().to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
 
     let violations = checker
         .check_sql("CREATE INDEX idx ON users(email);")
@@ -596,7 +567,7 @@ fn test_custom_check_using_pg_constants() {
         custom_checks_dir: Some(dir.path().to_str().unwrap().to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
 
     // DROP TABLE should fire
     let violations_table = checker.check_sql("DROP TABLE users;").unwrap();
@@ -646,7 +617,7 @@ fn test_multiple_custom_checks_loaded_in_sorted_order() {
         custom_checks_dir: Some(dir.path().to_str().unwrap().to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
 
     let violations = checker
         .check_sql("CREATE INDEX idx ON users(email);")
@@ -703,7 +674,7 @@ fn test_custom_check_name_conflicts_with_builtin() {
         disable_checks: vec!["AddColumnCheck".to_string()],
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
 
     let violations = checker
         .check_sql("ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;")
@@ -748,7 +719,7 @@ fn test_custom_check_compilation_error_nonfatal() {
         custom_checks_dir: Some(dir.path().to_str().unwrap().to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
 
     // check_sql should still work — broken script is skipped, valid one fires
     let violations = checker
@@ -801,6 +772,7 @@ fn test_custom_check_can_read_postgres_version() {
         ..Default::default()
     };
     let violations = SafetyChecker::with_config(config_pg14)
+        .unwrap()
         .check_sql("CREATE INDEX CONCURRENTLY idx ON users(email);")
         .unwrap();
     assert!(
@@ -817,6 +789,7 @@ fn test_custom_check_can_read_postgres_version() {
         ..Default::default()
     };
     let violations = SafetyChecker::with_config(config_pg13)
+        .unwrap()
         .check_sql("CREATE INDEX CONCURRENTLY idx ON users(email);")
         .unwrap();
     assert!(
@@ -833,6 +806,7 @@ fn test_custom_check_can_read_postgres_version() {
         ..Default::default()
     };
     let violations = SafetyChecker::with_config(config_no_ver)
+        .unwrap()
         .check_sql("CREATE INDEX CONCURRENTLY idx ON users(email);")
         .unwrap();
     assert!(
@@ -853,7 +827,7 @@ fn test_custom_check_runtime_error_yields_script_error_violation() {
         custom_checks_dir: Some(dir.path().to_str().unwrap().to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     // SELECT doesn't trigger any built-in check, so the only violation comes from the script.
     let violations = checker.check_sql("SELECT 1;").unwrap();
     assert_eq!(
@@ -883,7 +857,7 @@ fn test_custom_check_max_operations_yields_script_error() {
         custom_checks_dir: Some(dir.path().to_str().unwrap().to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let violations = checker.check_sql("SELECT 1;").unwrap();
     assert_eq!(
         violations.len(),

--- a/tests/diesel_adapter_test.rs
+++ b/tests/diesel_adapter_test.rs
@@ -24,7 +24,7 @@ fn test_diesel_loose_sql_and_directory_migrations_coexist() {
         framework: "diesel".to_string(),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -49,7 +49,7 @@ fn test_invalid_start_after_returns_error() {
         start_after: Some("not-a-timestamp".to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let err = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap_err();
@@ -92,7 +92,7 @@ fn test_diesel_mixed_timestamp_separators() {
         start_after: Some("2024_01_01_000000".to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -130,6 +130,7 @@ fn test_concurrently_violations_include_diesel_transaction_hint() {
         ..Default::default()
     };
     let results = SafetyChecker::with_config(config)
+        .unwrap()
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
 
@@ -178,7 +179,7 @@ fn test_diesel_no_separator_timestamp() {
         framework: "diesel".to_string(),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -218,6 +219,7 @@ disable_checks = ["AddColumnCheck"]
         ..Default::default()
     };
     let results = SafetyChecker::with_config(config)
+        .unwrap()
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
 

--- a/tests/error_handling_test.rs
+++ b/tests/error_handling_test.rs
@@ -5,7 +5,7 @@ use tempfile::tempdir;
 
 #[test]
 fn test_invalid_sql_produces_parse_error() {
-    let checker = SafetyChecker::new();
+    let checker = SafetyChecker::default();
     let result = checker.check_sql("NOT VALID SQL;");
     assert!(result.is_err(), "Invalid SQL should produce an error");
 
@@ -22,7 +22,7 @@ fn test_invalid_sql_in_migration_file_has_file_context() {
     let file_path = temp_dir.path().join("up.sql");
     fs::write(&file_path, "NOT VALID SQL;").unwrap();
 
-    let checker = SafetyChecker::new();
+    let checker = SafetyChecker::default();
     let utf8_path = Utf8Path::from_path(&file_path).unwrap();
     let result = checker.check_file(utf8_path);
 
@@ -44,7 +44,7 @@ fn test_empty_migration_file() {
     let file_path = temp_dir.path().join("up.sql");
     fs::write(&file_path, "").unwrap();
 
-    let checker = SafetyChecker::new();
+    let checker = SafetyChecker::default();
     let utf8_path = Utf8Path::from_path(&file_path).unwrap();
     let result = checker.check_file(utf8_path);
 
@@ -62,7 +62,7 @@ fn test_migration_file_with_only_comments() {
     let file_path = temp_dir.path().join("up.sql");
     fs::write(&file_path, "-- comment\n-- another comment\n").unwrap();
 
-    let checker = SafetyChecker::new();
+    let checker = SafetyChecker::default();
     let utf8_path = Utf8Path::from_path(&file_path).unwrap();
     let result = checker.check_file(utf8_path);
 
@@ -79,14 +79,14 @@ fn test_migration_file_with_only_comments() {
 
 #[test]
 fn test_nonexistent_file_returns_error() {
-    let checker = SafetyChecker::new();
+    let checker = SafetyChecker::default();
     let result = checker.check_file(Utf8Path::new("/nonexistent/path/to/migration.sql"));
     assert!(result.is_err(), "Nonexistent file should return an error");
 }
 
 #[test]
 fn test_nonexistent_path_returns_error() {
-    let checker = SafetyChecker::new();
+    let checker = SafetyChecker::default();
     let result = checker.check_path(Utf8Path::new("/nonexistent/path/to/migrations"));
     assert!(result.is_err(), "Nonexistent path should return an error");
 }
@@ -109,7 +109,7 @@ fn test_check_directory_fails_on_invalid_sql_file() {
     fs::create_dir(&invalid_dir).unwrap();
     fs::write(invalid_dir.join("up.sql"), "NOT VALID SQL SYNTAX HERE;").unwrap();
 
-    let checker = SafetyChecker::new();
+    let checker = SafetyChecker::default();
     let result = checker.check_directory(Utf8Path::from_path(temp_dir.path()).unwrap());
 
     // One bad file should fail the entire batch
@@ -123,7 +123,7 @@ fn test_check_directory_fails_on_invalid_sql_file() {
 fn test_empty_directory_returns_no_results() {
     let temp_dir = tempdir().expect("Failed to create temp dir");
 
-    let checker = SafetyChecker::new();
+    let checker = SafetyChecker::default();
     let result = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -142,7 +142,7 @@ fn test_directory_with_non_sql_files_ignored() {
     fs::write(temp_dir.path().join("notes.md"), "# Notes").unwrap();
 
     let config = Config::default();
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let result = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();

--- a/tests/fixtures_test.rs
+++ b/tests/fixtures_test.rs
@@ -24,6 +24,7 @@ fn checker_with_enabled_checks(checks: &[&str]) -> SafetyChecker {
         enable_checks: checks.iter().map(|check| (*check).to_string()).collect(),
         ..Default::default()
     })
+    .unwrap()
 }
 
 fn sqlx_checker_with_enabled_checks(checks: &[&str], check_down: bool) -> SafetyChecker {
@@ -33,6 +34,7 @@ fn sqlx_checker_with_enabled_checks(checks: &[&str], check_down: bool) -> Safety
         enable_checks: checks.iter().map(|check| (*check).to_string()).collect(),
         ..Default::default()
     })
+    .unwrap()
 }
 
 fn checker_with_disabled_checks(checks: &[&str]) -> SafetyChecker {
@@ -40,6 +42,7 @@ fn checker_with_disabled_checks(checks: &[&str]) -> SafetyChecker {
         disable_checks: checks.iter().map(|check| (*check).to_string()).collect(),
         ..Default::default()
     })
+    .unwrap()
 }
 
 fn sqlx_checker_with_disabled_checks(checks: &[&str], check_down: bool) -> SafetyChecker {
@@ -49,6 +52,7 @@ fn sqlx_checker_with_disabled_checks(checks: &[&str], check_down: bool) -> Safet
         disable_checks: checks.iter().map(|check| (*check).to_string()).collect(),
         ..Default::default()
     })
+    .unwrap()
 }
 
 #[test]
@@ -212,9 +216,10 @@ fn test_add_unique_index_without_concurrently_detected() {
 
     assert_eq!(violations.len(), 1, "Expected 1 violation");
     assert_eq!(violations[0].1.operation, "ADD INDEX without CONCURRENTLY");
-    assert!(
-        violations[0].1.problem.contains("UNIQUE"),
-        "Expected problem to mention UNIQUE"
+    assert_eq!(
+        violations[0].1.problem,
+        "Creating UNIQUE index 'idx_users_username' on table 'users' without CONCURRENTLY acquires a SHARE lock, \
+blocking writes (INSERT, UPDATE, DELETE). Duration depends on table size. Reads are still allowed."
     );
 }
 

--- a/tests/formatters_test.rs
+++ b/tests/formatters_test.rs
@@ -6,6 +6,7 @@ fn only(check_name: &str) -> SafetyChecker {
         enable_checks: vec![check_name.to_string()],
         ..Config::default()
     })
+    .unwrap()
 }
 
 #[test]
@@ -393,7 +394,8 @@ fn test_format_json_end_to_end() {
     let checker = SafetyChecker::with_config(Config {
         enable_checks: vec!["DropColumnCheck".to_string()],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let sql = "SELECT 1;\nALTER TABLE users DROP COLUMN email;";
     let violations = checker.check_sql(sql).unwrap();
 
@@ -622,7 +624,7 @@ fn checker_with_custom_checks(
         custom_checks_dir: Some(custom_dir.to_str().unwrap().to_string()),
         ..Config::default()
     };
-    let checker = SafetyChecker::with_config(config.clone());
+    let checker = SafetyChecker::with_config(config.clone()).unwrap();
     // Verify the custom check was loaded
     let check_stem = script_name.trim_end_matches(".rhai");
     let loaded = checker

--- a/tests/safety_assured_test.rs
+++ b/tests/safety_assured_test.rs
@@ -8,7 +8,8 @@ fn test_safety_assured_block_ignores_violations() {
     let checker = SafetyChecker::with_config(Config {
         enable_checks: vec!["DropColumnCheck".to_string()],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let sql = r"
 -- safety-assured:start
 ALTER TABLE users DROP COLUMN email;
@@ -29,7 +30,8 @@ fn test_without_safety_assured_detects_violations() {
     let checker = SafetyChecker::with_config(Config {
         enable_checks: vec!["DropColumnCheck".to_string()],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let sql = r"
 ALTER TABLE users DROP COLUMN email;
 ALTER TABLE posts DROP COLUMN body;
@@ -48,7 +50,8 @@ fn test_partial_safety_assured() {
     let checker = SafetyChecker::with_config(Config {
         enable_checks: vec!["DropColumnCheck".to_string()],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let sql = r"
 ALTER TABLE users DROP COLUMN email;
 
@@ -79,7 +82,8 @@ fn test_multiple_blocks() {
     let checker = SafetyChecker::with_config(Config {
         enable_checks: vec!["DropColumnCheck".to_string()],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let sql = r"
 -- safety-assured:start
 ALTER TABLE users DROP COLUMN email;
@@ -101,7 +105,8 @@ fn test_case_insensitive() {
     let checker = SafetyChecker::with_config(Config {
         enable_checks: vec!["DropColumnCheck".to_string()],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let sql = r"
 -- SAFETY-ASSURED:START
 ALTER TABLE users DROP COLUMN email;
@@ -121,7 +126,8 @@ fn test_unclosed_block_error() {
     let checker = SafetyChecker::with_config(Config {
         enable_checks: vec!["DropColumnCheck".to_string()],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let sql = r"
 -- safety-assured:start
 ALTER TABLE users DROP COLUMN email;
@@ -138,7 +144,7 @@ ALTER TABLE users DROP COLUMN email;
 
 #[test]
 fn test_unmatched_end_error() {
-    let checker = SafetyChecker::new();
+    let checker = SafetyChecker::default();
     let sql = r"
 ALTER TABLE users DROP COLUMN email;
 -- safety-assured:end
@@ -169,7 +175,7 @@ ALTER TABLE users DROP COLUMN deprecated_column;
     )
     .unwrap();
 
-    let checker = SafetyChecker::new();
+    let checker = SafetyChecker::default();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -183,7 +189,7 @@ ALTER TABLE users DROP COLUMN deprecated_column;
 
 #[test]
 fn test_empty_block() {
-    let checker = SafetyChecker::new();
+    let checker = SafetyChecker::default();
     let sql = r"
 -- safety-assured:start
 -- safety-assured:end
@@ -198,7 +204,8 @@ fn test_comments_within_block() {
     let checker = SafetyChecker::with_config(Config {
         enable_checks: vec!["DropColumnCheck".to_string()],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let sql = r"
 -- safety-assured:start
 -- This column was deprecated 6 months ago
@@ -220,7 +227,8 @@ fn test_multiline_statement_in_block() {
     let checker = SafetyChecker::with_config(Config {
         enable_checks: vec!["DropColumnCheck".to_string()],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let sql = r"
 -- safety-assured:start
 ALTER TABLE users
@@ -241,7 +249,8 @@ fn test_mixed_safe_and_unsafe_operations() {
     let checker = SafetyChecker::with_config(Config {
         enable_checks: vec!["AddColumnCheck".to_string(), "DropColumnCheck".to_string()],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let sql = r"
 -- Safe operation - no default
 ALTER TABLE users ADD COLUMN email VARCHAR(255);
@@ -271,7 +280,8 @@ fn test_per_migration_disable_directive_skips_only_named_check() {
             "IdempotencyAlterCheck".to_string(),
         ],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let sql = r"
 -- diesel-guard:disable AddColumnCheck
 ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
@@ -293,7 +303,8 @@ fn test_per_migration_disable_directive_accepts_multiple_checks() {
             "IdempotencyAlterCheck".to_string(),
         ],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let sql = r"
 -- diesel-guard:disable AddColumnCheck, IdempotencyAlterCheck
 ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
@@ -305,7 +316,7 @@ ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
 
 #[test]
 fn test_nested_blocks() {
-    let checker = SafetyChecker::new();
+    let checker = SafetyChecker::default();
     let sql = r"
 -- safety-assured:start
 ALTER TABLE users DROP COLUMN email;
@@ -325,7 +336,7 @@ ALTER TABLE posts DROP COLUMN body;
 
 #[test]
 fn test_block_with_multiple_statement_types() {
-    let checker = SafetyChecker::new();
+    let checker = SafetyChecker::default();
     let sql = r"
 -- safety-assured:start
 ALTER TABLE users DROP COLUMN email;
@@ -345,7 +356,7 @@ CREATE INDEX users_idx ON users(name);
 #[test]
 fn test_block_with_multiple_same_operation_type() {
     // Edge case: Multiple ALTER statements (same keyword) within block
-    let checker = SafetyChecker::new();
+    let checker = SafetyChecker::default();
     let sql = r"
 -- safety-assured:start
 ALTER TABLE users DROP COLUMN deprecated_a;
@@ -368,7 +379,8 @@ fn test_interleaved_blocks_and_statements_same_keyword() {
     let checker = SafetyChecker::with_config(Config {
         enable_checks: vec!["DropColumnCheck".to_string()],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let sql = r"
 ALTER TABLE users DROP COLUMN a;
 
@@ -405,7 +417,8 @@ fn test_safety_assured_with_leading_whitespace() {
     let checker = SafetyChecker::with_config(Config {
         enable_checks: vec!["DropColumnCheck".to_string()],
         ..Default::default()
-    });
+    })
+    .unwrap();
     let sql = r"
 
     -- safety-assured:start

--- a/tests/sqlx_adapter_test.rs
+++ b/tests/sqlx_adapter_test.rs
@@ -15,7 +15,7 @@ fn test_invalid_start_after_returns_error() {
         start_after: Some("not-a-timestamp".to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let err = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap_err();
@@ -49,6 +49,7 @@ fn test_concurrently_violations_include_sqlx_transaction_hint() {
         ..Default::default()
     };
     let results = SafetyChecker::with_config(config)
+        .unwrap()
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
 
@@ -104,7 +105,7 @@ fn test_sqlx_numeric_version_comparison() {
         start_after: Some("2".to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -133,7 +134,7 @@ fn test_sqlx_single_file_format_no_markers() {
         framework: "sqlx".to_string(),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -168,7 +169,7 @@ fn test_sqlx_start_after_with_suffix_format() {
         start_after: Some("1".to_string()),
         ..Default::default()
     };
-    let checker = SafetyChecker::with_config(config);
+    let checker = SafetyChecker::with_config(config).unwrap();
     let results = checker
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -199,7 +200,7 @@ fn test_sqlx_check_down_suffix_format() {
         check_down: false,
         ..Default::default()
     };
-    let checker_no_down = SafetyChecker::with_config(config_no_down);
+    let checker_no_down = SafetyChecker::with_config(config_no_down).unwrap();
     let results_no_down = checker_no_down
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -213,7 +214,7 @@ fn test_sqlx_check_down_suffix_format() {
         check_down: true,
         ..Default::default()
     };
-    let checker_down = SafetyChecker::with_config(config_down);
+    let checker_down = SafetyChecker::with_config(config_down).unwrap();
     let results_down = checker_down
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
@@ -249,6 +250,7 @@ ALTER TABLE users ADD COLUMN admin BOOLEAN DEFAULT FALSE;
         ..Default::default()
     };
     let results = SafetyChecker::with_config(config)
+        .unwrap()
         .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap())
         .unwrap();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Configuration validation is stricter: unknown check names in enable/disable/warn now return an error (instead of continuing with warnings/partial setup).
  * The checker now fails immediately when configuration is invalid, rather than proceeding with inconsistent settings.
  * Configuration/initialization errors are reported with clearer diagnostic formatting.

* **Documentation**
  * Added crate-level Rustdoc introducing `diesel-guard`, including a quick-start example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->