### PR TITLE
Help text points to a non-existent `-list-checks` flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,7 @@ fn run_explain(check_name: &str, format: Format) -> Result<()> {
         .find(|c| c.name() == check_name)
     else {
         eprintln!("Error: No check named '{check_name}'.");
-        eprintln!("Run --list-checks to see available checks.");
+        eprintln!("Run list-checks to see available checks.");
         exit(1);
     };
     print!("{}", format.formatter().format_explain(check, &config));

--- a/src/safety_checker.rs
+++ b/src/safety_checker.rs
@@ -126,7 +126,7 @@ impl SafetyChecker {
                 .any(|known| known.as_str() == name)
             {
                 eprintln!(
-                    "Warning: Unknown check name '{name}' in {source}. Run --list-checks to see available checks."
+                    "Warning: Unknown check name '{name}' in {source}. Run list-checks to see available checks."
                 );
             }
         }

--- a/src/scripting.rs
+++ b/src/scripting.rs
@@ -444,6 +444,10 @@ mod tests {
             violations[1].problem,
             "Custom check returned a non-map array element: expected a map, got string"
         );
+        assert_eq!(
+            violations[1].safe_alternative,
+            "Fix the custom check script to return maps with operation, problem, and safe_alternative keys."
+        );
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error and warning messages to reference the correct command syntax for listing checks.

* **Tests**
  * Enhanced validation for custom check script error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->