### PR TITLE
SQLx `start_after` rejects documented separator timestamp formats

### DIFF
--- a/src/adapters/diesel.rs
+++ b/src/adapters/diesel.rs
@@ -10,7 +10,7 @@
 
 use super::{
     MigrationAdapter, MigrationContext, MigrationFile, Result, collect_and_sort_entries,
-    is_single_migration_dir, should_check_migration,
+    is_single_migration_dir, normalize_timestamp, should_check_migration,
 };
 use camino::Utf8Path;
 use regex::Regex;
@@ -81,7 +81,7 @@ impl MigrationAdapter for DieselAdapter {
         DIESEL_TIMESTAMP_REGEX
             .captures(name)
             .and_then(|cap| cap.get(1))
-            .map(|m| m.as_str().replace(['_', '-'], ""))
+            .map(|m| normalize_timestamp(m.as_str()))
     }
 
     fn validate_timestamp(&self, timestamp: &str) -> Result<()> {

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -126,6 +126,10 @@ pub trait MigrationAdapter: Send + Sync {
     fn extract_migration_metadata(&self, file_path: &Utf8Path) -> MigrationContext;
 }
 
+pub(crate) fn normalize_timestamp(ts: &str) -> String {
+    ts.replace(['_', '-'], "")
+}
+
 /// Check if migration should be checked based on start_after filter.
 ///
 /// Returns true if the migration should be checked (timestamp is after the filter).
@@ -135,8 +139,8 @@ pub(crate) fn should_check_migration(start_after: Option<&str>, migration_timest
     };
 
     // Normalize both timestamps by removing separators
-    let start_normalized = start_after.replace(['_', '-'], "");
-    let migration_normalized = migration_timestamp.replace(['_', '-'], "");
+    let start_normalized = normalize_timestamp(start_after);
+    let migration_normalized = normalize_timestamp(migration_timestamp);
 
     // If both are purely numeric, compare as integers to handle variable-width
     // version numbers (e.g. "2" vs "10"). Otherwise fall back to string comparison

--- a/src/adapters/sqlx.rs
+++ b/src/adapters/sqlx.rs
@@ -20,6 +20,12 @@ use std::sync::LazyLock;
 static SQLX_VERSION_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(\d+)(_|\.)?").expect("valid regex pattern"));
 
+/// Regex for validating `start_after` config values: a plain positive integer, or a
+/// separator-formatted 14-digit timestamp (`YYYY_MM_DD_HHMMSS` / `YYYY-MM-DD-HHMMSS`).
+static SQLX_START_AFTER_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^\d+$|^\d{4}[_-]\d{2}[_-]\d{2}[_-]\d{6}$").expect("valid regex pattern")
+});
+
 const NO_TRANSACTION_HINT: &str =
     "Add `-- no-transaction` as the first line of the migration file.";
 
@@ -57,7 +63,7 @@ impl MigrationAdapter for SqlxAdapter {
     }
 
     fn validate_timestamp(&self, timestamp: &str) -> Result<()> {
-        if !timestamp.is_empty() && timestamp.chars().all(|c| c.is_ascii_digit()) {
+        if SQLX_START_AFTER_REGEX.is_match(timestamp) {
             Ok(())
         } else {
             Err(
@@ -212,8 +218,12 @@ mod tests {
         assert!(adapter.validate_timestamp("1").is_ok());
         assert!(adapter.validate_timestamp("001").is_ok());
         assert!(adapter.validate_timestamp("42").is_ok());
+        assert!(adapter.validate_timestamp("2024_01_01_000000").is_ok());
+        assert!(adapter.validate_timestamp("2024-01-01-000000").is_ok());
         assert!(adapter.validate_timestamp("").is_err());
         assert!(adapter.validate_timestamp("invalid").is_err());
+        assert!(adapter.validate_timestamp("-1").is_err());
+        assert!(adapter.validate_timestamp("1-2").is_err());
     }
 
     #[test]

--- a/tests/sqlx_adapter_test.rs
+++ b/tests/sqlx_adapter_test.rs
@@ -5,6 +5,32 @@ use std::fs;
 use tempfile::tempdir;
 
 #[test]
+fn test_start_after_accepts_separator_formats() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    fs::write(
+        temp_dir.path().join("20240102000000_add_col.sql"),
+        "ALTER TABLE users ADD COLUMN email TEXT;",
+    )
+    .unwrap();
+
+    for start_after in &["2024_01_01_000000", "2024-01-01-000000", "20240101000000"] {
+        let config = Config {
+            framework: "sqlx".to_string(),
+            start_after: Some((*start_after).to_string()),
+            ..Default::default()
+        };
+        let results = SafetyChecker::with_config(config)
+            .unwrap()
+            .check_directory(Utf8Path::from_path(temp_dir.path()).unwrap());
+        assert!(
+            results.is_ok(),
+            "start_after={start_after} should be accepted, got: {:?}",
+            results.unwrap_err()
+        );
+    }
+}
+
+#[test]
 fn test_invalid_start_after_returns_error() {
     let temp_dir = tempdir().expect("Failed to create temp dir");
     let mig = temp_dir.path().join("20240101000000_create_users.sql");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `start_after` now supports multiple timestamp formats for SQLx, including underscore-separated, hyphen-separated, and compact (no-separator) variants.

* **Bug Fixes**
  * Timestamp normalization is now applied consistently when selecting migrations, ensuring equivalent timestamps are treated the same way.

* **Tests**
  * Added coverage to verify SQLx accepts the supported `start_after` timestamp formats and rejects invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->