### PR TITLE
Clarify SQLx start_after formats

### DIFF
--- a/diesel-guard.toml.example
+++ b/diesel-guard.toml.example
@@ -13,8 +13,8 @@ framework = "diesel"
 # Timestamp format depends on your framework:
 #   Diesel: YYYYMMDDHHMMSS, YYYY_MM_DD_HHMMSS, or YYYY-MM-DD-HHMMSS
 #           Examples: 20240101000000, 2024_01_01_000000, 2024-01-01-000000
-#   SQLx:   YYYYMMDDHHMMSS (14 digits, no separators)
-#           Example: 20240101000000
+#   SQLx:   plain numeric versions, or separator-formatted 14-digit timestamps
+#           Examples: 42, 20240101000000, 2024_01_01_000000, 2024-01-01-000000
 #
 # Works with any format - diesel-guard normalizes timestamps for comparison
 # start_after = "20240101000000"

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -25,8 +25,8 @@ diesel-guard init --force
 framework = "diesel"
 
 # Skip migrations before this timestamp
-# Accepts: YYYYMMDDHHMMSS, YYYY_MM_DD_HHMMSS, or YYYY-MM-DD-HHMMSS
-# Works with any migration directory format
+# Accepts Diesel timestamps and SQLx numeric versions:
+#   42, 20240101000000, 2024_01_01_000000, or 2024-01-01-000000
 start_after = "2024_01_01_000000"
 
 # Also check down.sql files (default: false)

--- a/docs/src/frameworks.md
+++ b/docs/src/frameworks.md
@@ -42,7 +42,7 @@ migrations/
 └── 20240101000000_create_users.sql
 ```
 
-SQLx versions are any positive integer (e.g., `1`, `001`, `42`, `20240101000000`). Short numeric versions use numeric comparison for `start_after` filtering; 14-digit timestamps use string comparison.
+SQLx migration versions are any positive integer (e.g., `1`, `001`, `42`, `20240101000000`). Short numeric versions use numeric comparison for `start_after` filtering; separator-formatted timestamp filters such as `2024_01_01_000000` and `2024-01-01-000000` are normalized before comparison.
 
 ## Framework Configuration
 

--- a/skills/diesel-guard/SKILL.md
+++ b/skills/diesel-guard/SKILL.md
@@ -74,8 +74,9 @@ fixes from memory.
 Run `diesel-guard init` to scaffold the file (use `--force` to overwrite). Keys:
 
 - `framework` (**required**) — `"diesel"` or `"sqlx"`. Case-sensitive.
-- `start_after` — skip migrations older than this timestamp (Diesel accepts `YYYYMMDDHHMMSS`,
-  `YYYY_MM_DD_HHMMSS`, `YYYY-MM-DD-HHMMSS`; SQLx uses the version number). Good for retrofitting.
+- `start_after` — skip migrations older than this timestamp. Diesel accepts `YYYYMMDDHHMMSS`,
+  `YYYY_MM_DD_HHMMSS`, and `YYYY-MM-DD-HHMMSS`; SQLx accepts plain numeric versions like `42`
+  and separator-formatted 14-digit timestamp filters. Good for retrofitting.
 - `check_down` (default `false`) — also check rollback/down migrations.
 - `disable_checks` — blacklist of check names to skip.
 - `enable_checks` — whitelist; only these run. **Mutually exclusive** with `disable_checks`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified accepted `start_after` timestamp and version formats for migration filtering.
  * Added clearer examples for both numeric versions and separator-formatted timestamps.
  * Updated wording to better explain how timestamp values are interpreted during comparison.
  * Reflowed related configuration guidance for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->