### PR TITLE
Remove docs/ from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 .git
 .github
 target/
-docs/
 tests/
 examples/
 *.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,17 +85,13 @@ jobs:
         with:
           toolchain: 1.96.0
 
-      - name: Cache cargo tools
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-tarpaulin-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Install just
         uses: extractions/setup-just@v4
 
       - name: Install tarpaulin
-        run: cargo install --locked cargo-tarpaulin || true
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-tarpaulin
 
       - name: Generate coverage report
         run: just coverage
@@ -133,3 +129,17 @@ jobs:
       - name: Validate commit messages
         run: |
           npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.sha }} --verbose
+
+  # Build the Docker image on every merge to main (build-only, no push) so a
+  # Dockerfile/.dockerignore break surfaces here instead of at release time.
+  # Manual ad-hoc builds use the Docker workflow's workflow_dispatch trigger.
+  docker-build:
+    name: Docker build
+    needs: tests
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/docker.yml
+    with:
+      push: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,57 @@
+name: Docker
+
+on:
+  workflow_call:
+    inputs:
+      push:
+        type: boolean
+        default: false
+      platforms:
+        type: string
+        default: linux/amd64,linux/arm64
+      image:
+        type: string
+        default: ayarotsky/diesel-guard
+  workflow_dispatch:
+    inputs:
+      push:
+        type: boolean
+        default: false
+      platforms:
+        type: string
+        default: linux/amd64,linux/arm64
+      image:
+        type: string
+        default: ayarotsky/diesel-guard
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: read
+      id-token: write
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    with:
+      output: image
+      push: ${{ inputs.push }}
+      platforms: ${{ inputs.platforms }}
+      cache: true
+      cache-mode: max
+      sign: auto
+      sbom: true
+      set-meta-labels: true
+      set-meta-annotations: true
+      meta-images: ${{ inputs.image }}
+      meta-tags: |
+        type=semver,pattern={{version}}
+        type=semver,pattern={{major}}.{{minor}}
+      meta-flavor: |
+        latest=true
+    secrets:
+      # Ignored on build-only runs: the builder only logs in when push is true.
+      registry-auths: |
+        - registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,47 +348,14 @@ jobs:
     needs:
       - plan
       - host
-    runs-on: ubuntu-latest
-    environment: release
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract metadata for Docker
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ayarotsky/diesel-guard
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-          flavor: |
-            latest=true
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/docker.yml
+    with:
+      push: true
+    secrets: inherit
 
   announce:
     needs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,37 @@
-FROM rust:1.96.0 AS builder
+FROM rust:1.96.0 AS chef
+RUN cargo install cargo-chef --locked
+WORKDIR /app
 
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
 ARG TARGETARCH
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends musl-tools clang libclang-dev protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
-COPY . .
+COPY --from=planner /app/recipe.json recipe.json
 
+# Cook dependencies in their own layer. As long as recipe.json is unchanged
+# (i.e. no dependency changes), this layer is reused and only application code
+# is recompiled below.
 RUN case "$TARGETARCH" in \
       amd64) TRIPLE="x86_64-unknown-linux-musl" ;; \
       arm64) TRIPLE="aarch64-unknown-linux-musl" ;; \
       *) echo "Unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
     esac \
+    && echo "$TRIPLE" > /triple \
     && rustup target add "$TRIPLE" \
+    && CC=musl-gcc \
+       RUSTFLAGS="-C linker=musl-gcc" \
+       cargo chef cook --release --target "$TRIPLE" --recipe-path recipe.json
+
+COPY . .
+
+RUN TRIPLE="$(cat /triple)" \
     && CC=musl-gcc \
        RUSTFLAGS="-C linker=musl-gcc" \
        cargo build --release --target "$TRIPLE" \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable, on-demand Docker image workflow with multi-platform builds.
  * CI now runs build-only Docker validations on main merges (no publishing).
* **Bug Fixes**
  * Docker builds now include the `docs/` directory (it’s no longer excluded).
* **Chores**
  * Simplified Docker image publishing by delegating build/push to the reusable workflow.
  * Improved Docker build performance using dependency caching, with SBOM generation and image signing enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->